### PR TITLE
UserPreferencesRepository with DataStore and FavoritesFlow from User Preferences

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.gms:play-services-location:21.1.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.media3:media3-common:1.3.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
@@ -80,6 +81,7 @@ dependencies {
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
     implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")
+    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
 
     //Maps
     implementation ("com.google.maps.android:maps-compose:4.0.0")
@@ -111,5 +113,9 @@ dependencies {
     //Navigation
     implementation("androidx.hilt:hilt-navigation-fragment:1.1.0")
     implementation("androidx.hilt:hilt-navigation-compose:1.2.0-rc01")
+
+    //Datastore
+    implementation ("androidx.datastore:datastore-preferences:1.0.0")
+
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -23,7 +23,6 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
     private suspend fun getRoute(request: RouteRequest): Payload<RouteOptions> =
         networkApi.getRoute(request)
 
-
     private val _stopFlow: MutableStateFlow<ApiResponse<List<Stop>>> =
         MutableStateFlow(ApiResponse.Pending)
 

--- a/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.SharingStarted
@@ -12,9 +13,14 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import javax.inject.Inject
+import javax.inject.Singleton
 
-
-class UserPreferenceRepository(context: Context) {
+/**
+ * Repository to store data related to user preferences
+ */
+@Singleton
+class UserPreferenceRepository @Inject constructor(@ApplicationContext val context: Context) {
 
     /**
      * User Preferences file for Transit
@@ -47,12 +53,10 @@ class UserPreferenceRepository(context: Context) {
      */
     val favoritesFlow: StateFlow<Set<String>> = dataStore.data
         .catch {
-            val empty: Set<String> = setOf()
-            empty
+            setOf<String>()
         }
         .map { preferences ->
-            val empty: Set<String> = setOf()
-            val favorites = preferences[FAVORITES_MAP] ?: empty
+            val favorites = preferences[FAVORITES_MAP] ?: setOf<String>()
             favorites
         }.stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, emptySet())
 

--- a/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
@@ -1,0 +1,59 @@
+package com.cornellappdev.transit.models
+
+
+import android.content.Context
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+
+class UserPreferenceRepository(context: Context) {
+
+    /**
+     * User Preferences file for Transit
+     */
+    private val Context.dataStore by preferencesDataStore(
+        name = "UserPreferences"
+    )
+
+    private val dataStore = context.dataStore
+
+    /**
+     * Key values for the preferences stored in User Preferences
+     */
+    companion object PreferencesKeys {
+        val FAVORITES_MAP = stringSetPreferencesKey("favorites")
+    }
+
+    /**
+     * Sets favorites in user preferences
+     * @param favorites: The set containing names of stops that have been favorites
+     */
+    suspend fun setFavorites(favorites: Set<String>) {
+        dataStore.edit { preferences ->
+            preferences[FAVORITES_MAP] = favorites
+        }
+    }
+
+    /**
+     * Flow of favorite stops
+     */
+    val favoritesFlow: StateFlow<Set<String>> = dataStore.data
+        .catch {
+            val empty: Set<String> = setOf()
+            empty
+        }
+        .map { preferences ->
+            val empty: Set<String> = setOf()
+            val favorites = preferences[FAVORITES_MAP] ?: empty
+            favorites
+        }.stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, emptySet())
+
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.models.Stop
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
+import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 
 
 /**
@@ -36,7 +38,8 @@ fun BottomSheetContent(
     editText: String,
     editState: Boolean,
     data: List<Stop>,
-    onclick: () -> Unit
+    onclick: () -> Unit,
+    favoritesViewModel: FavoritesViewModel = hiltViewModel()
 ) {
     Column() {
         Row(
@@ -77,7 +80,7 @@ fun BottomSheetContent(
                     sublabel = it.type,
                     editing = editState,
                     addOnClick = {},
-                    removeOnClick = {}
+                    removeOnClick = { favoritesViewModel.removeFavorite(it.name) },
                 )
             }
             item {
@@ -87,7 +90,7 @@ fun BottomSheetContent(
                     label = "Add",
                     sublabel = "",
                     editing = editState,
-                    addOnClick = {},
+                    addOnClick = {}, //add function to run when "Add' is clicked
                     removeOnClick = {}
                 )
             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/LocationItem.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/LocationItem.kt
@@ -23,6 +23,8 @@ import androidx.compose.ui.unit.sp
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 /**
  * Card for each entry in favourite locations list
@@ -70,7 +72,6 @@ fun LocationItem(
                         .align(Alignment.TopEnd)
                         .size(20.dp)
                         .clickable(onClick = removeOnClick)
-
                 )
 
             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/LocationItem.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/LocationItem.kt
@@ -23,8 +23,6 @@ import androidx.compose.ui.unit.sp
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 /**
  * Card for each entry in favourite locations list

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -207,14 +207,14 @@ fun HomeScreen(
         scaffoldState = scaffoldState,
         sheetSwipeEnabled = true,
         sheetContent = {
-            BottomSheetContent(txt, editState, data) {
+            BottomSheetContent(txt, editState, data, {
                 editState = editState == false
                 txt = if (editState) {
                     "Done"
                 } else {
                     "Edit"
                 }
-            }
+            })
         }
     ) {
     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -2,16 +2,12 @@ package com.cornellappdev.transit.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import com.cornellappdev.transit.models.RouteRepository
-import com.cornellappdev.transit.models.Stop
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -29,8 +25,8 @@ class FavoritesViewModel @Inject constructor(
     /**
      * A flow emitting all the locations and whether or not they have been favorited.
      */
-    //private val favoritesFlow = userPreferenceRepository.favoritesFlow
-    private val favoritesFlow: StateFlow<Set<String>> = MutableStateFlow(setOf("Gates Hall", "Duffield")).asStateFlow()
+    private val favoritesFlow = userPreferenceRepository.favoritesFlow
+    //private val favoritesFlow: StateFlow<Set<String>> = MutableStateFlow(setOf("Gates Hall", "Duffield")).asStateFlow()
 
     /**
      * Flow of all TCAT stops

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.transit.ui.viewmodels
 
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import com.cornellappdev.transit.models.RouteRepository
 import com.cornellappdev.transit.models.Stop
@@ -36,41 +35,33 @@ class FavoritesViewModel @Inject constructor(
     /**
      * Flow of all TCAT stops
      */
-    //private val stopFlow = routeRepository.stopFlow
-    private val stopFlow: StateFlow<List<Stop>> = MutableStateFlow(List(4){Stop(3.3, 3.3, "Gates Hall", "type?")}).asStateFlow()
+    private val stopFlow = routeRepository.stopFlow
 
     private val scope = CoroutineScope(Dispatchers.Default)
 
     /**
      * A flow emitting all the locations the user has favorited as a list of stops.
      */
-//    val favoriteStops = stopFlow.combine(
-//        favoritesFlow
-//    ) { apiResponse, favorites ->
-//        when (apiResponse) {
-//            is ApiResponse.Error -> {
-//                emptyList()
-//            }
-//
-//            is ApiResponse.Pending -> {
-//                emptyList()
-//            }
-//
-//            is ApiResponse.Success -> {
-//                apiResponse.data.filter { stop ->
-//                    favorites.contains(stop.name)
-//                }
-//            }
-//        }
-//    }.stateIn(scope, SharingStarted.Eagerly, emptyList())
-
     val favoriteStops = stopFlow.combine(
         favoritesFlow
     ) { apiResponse, favorites ->
-        apiResponse.filter { stop ->
-            favorites.contains(stop.name)
+        when (apiResponse) {
+            is ApiResponse.Error -> {
+                emptyList()
+            }
+
+            is ApiResponse.Pending -> {
+                emptyList()
+            }
+
+            is ApiResponse.Success -> {
+                apiResponse.data.filter { stop ->
+                    favorites.contains(stop.name)
+                }
+            }
         }
     }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+
 
 
     /**

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -17,7 +17,7 @@ import javax.inject.Inject
  */
 @HiltViewModel
 class FavoritesViewModel @Inject constructor(
-    private val routeRepository: RouteRepository,
+    routeRepository: RouteRepository,
     private val userPreferenceRepository: UserPreferenceRepository
 ) : ViewModel() {
 
@@ -64,7 +64,7 @@ class FavoritesViewModel @Inject constructor(
     suspend fun removeFavorite(stop: String?) {
         if (stop != null) {
             val currentFavorites = favoritesFlow.value.toMutableSet()
-            val wasRemoved = currentFavorites.remove(stop)
+            currentFavorites.remove(stop)
             userPreferenceRepository.setFavorites(currentFavorites.toSet())
 
         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -1,15 +1,21 @@
 package com.cornellappdev.transit.ui.viewmodels
 
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
 import com.cornellappdev.transit.models.RouteRepository
+import com.cornellappdev.transit.models.Stop
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -24,49 +30,72 @@ class FavoritesViewModel @Inject constructor(
     /**
      * A flow emitting all the locations and whether or not they have been favorited.
      */
-    private val favoritesFlow = userPreferenceRepository.favoritesFlow
-
+    //private val favoritesFlow = userPreferenceRepository.favoritesFlow
+    private val favoritesFlow: StateFlow<Set<String>> = MutableStateFlow(setOf("Gates Hall", "Duffield")).asStateFlow()
 
     /**
      * Flow of all TCAT stops
      */
-    private val stopFlow = routeRepository.stopFlow
+    //private val stopFlow = routeRepository.stopFlow
+    private val stopFlow: StateFlow<List<Stop>> = MutableStateFlow(List(4){Stop(3.3, 3.3, "Gates Hall", "type?")}).asStateFlow()
 
     private val scope = CoroutineScope(Dispatchers.Default)
 
     /**
      * A flow emitting all the locations the user has favorited as a list of stops.
      */
+//    val favoriteStops = stopFlow.combine(
+//        favoritesFlow
+//    ) { apiResponse, favorites ->
+//        when (apiResponse) {
+//            is ApiResponse.Error -> {
+//                emptyList()
+//            }
+//
+//            is ApiResponse.Pending -> {
+//                emptyList()
+//            }
+//
+//            is ApiResponse.Success -> {
+//                apiResponse.data.filter { stop ->
+//                    favorites.contains(stop.name)
+//                }
+//            }
+//        }
+//    }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+
     val favoriteStops = stopFlow.combine(
         favoritesFlow
     ) { apiResponse, favorites ->
-        when (apiResponse) {
-            is ApiResponse.Error -> {
-                emptyList()
-            }
-
-            is ApiResponse.Pending -> {
-                emptyList()
-            }
-
-            is ApiResponse.Success -> {
-                apiResponse.data.filter { stop ->
-                    favorites.contains(stop.name)
-                }
-            }
+        apiResponse.filter { stop ->
+            favorites.contains(stop.name)
         }
     }.stateIn(scope, SharingStarted.Eagerly, emptyList())
 
 
     /**
-     * Function to remove a stop from favorites
+     * Asynchronous function to remove a stop from favorites
      */
-    suspend fun removeFavorite(stop: String?) {
+    fun removeFavorite(stop: String?) {
         if (stop != null) {
             val currentFavorites = favoritesFlow.value.toMutableSet()
             currentFavorites.remove(stop)
-            userPreferenceRepository.setFavorites(currentFavorites.toSet())
+            CoroutineScope(Dispatchers.IO).launch {
+                userPreferenceRepository.setFavorites(currentFavorites.toSet())
+            }
+        }
+    }
 
+    /**
+     * Asynchronous function to add a stop to favorites
+     */
+    fun addFavorite(stop: String?) {
+        if (stop != null) {
+            val currentFavorites = favoritesFlow.value.toMutableSet()
+            currentFavorites.add(stop)
+            CoroutineScope(Dispatchers.IO).launch {
+                userPreferenceRepository.setFavorites(currentFavorites.toSet())
+            }
         }
     }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.transit.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.RouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
@@ -67,7 +68,7 @@ class FavoritesViewModel @Inject constructor(
         if (stop != null) {
             val currentFavorites = favoritesFlow.value.toMutableSet()
             currentFavorites.remove(stop)
-            CoroutineScope(Dispatchers.IO).launch {
+            viewModelScope.launch {
                 userPreferenceRepository.setFavorites(currentFavorites.toSet())
             }
         }
@@ -80,7 +81,7 @@ class FavoritesViewModel @Inject constructor(
         if (stop != null) {
             val currentFavorites = favoritesFlow.value.toMutableSet()
             currentFavorites.add(stop)
-            CoroutineScope(Dispatchers.IO).launch {
+            viewModelScope.launch {
                 userPreferenceRepository.setFavorites(currentFavorites.toSet())
             }
         }


### PR DESCRIPTION
- Add UserPreferenceRepository using PReferences Datastore that contains a StateFlow of Favorites (Set of Strings)
- Modify FavoritesViewModel to use a set of strings instead of a map of strings and bools in combining favorites and stops
- Add functionality to update a stop in UserPreferencesRepository 
- Add functionality to remove a stop in FavoritesViewModel