### PR TITLE
Changing Stop Type and Favorite Type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# ithaca-transit-compose
-An open-source Android app for the TCAT bus service
+# Ithaca Transit
+
+<p align="center"><img src="https://github.com/cuappdev/assets/blob/master/app-icons/Transit-83.5x83.5%402x.png" width=210 /></p>
+
+Introducing Ithaca Transit, a new end-to-end navigation service for built for the TCAT bus service. A free and open-source app, Ithaca Transit offers a diverse range of features in a beautiful, clean interface to help get you where you need to go.
+
+## Getting Started
+
+1. Clone the repository.
+2. Create the file `secrets.properties` at the root directory of the repo. The format is as follows:
+
+```bash
+MAPS_KEY=""
+BACKEND_URL=""
+
+```
+
+3. Build the project.
+
+## Documentation
+For a quick overview of the codebase, check out the [project wiki](https://github.com/cuappdev/ithaca-transit-compose/wiki)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     id("com.google.android.libraries.mapsplatform.secrets-gradle-plugin")
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
+    id("kotlinx-serialization")
 }
 
 secrets {
@@ -72,7 +73,7 @@ dependencies {
     implementation("androidx.compose.material:material:1.6.5")
     implementation("androidx.compose.material3:material3")
     implementation("com.google.android.gms:play-services-location:21.1.0")
-    implementation ("androidx.compose.material3:material3:1.1.0-alpha02")
+    implementation("androidx.compose.material3:material3:1.1.0-alpha02")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.media3:media3-common:1.3.0")
     testImplementation("junit:junit:4.13.2")
@@ -82,12 +83,13 @@ dependencies {
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-    implementation ("androidx.constraintlayout:constraintlayout-compose:1.0.1")
-    implementation ("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
 
     //Maps
-    implementation ("com.google.maps.android:maps-compose:4.0.0")
-    implementation ("com.google.android.gms:play-services-maps:18.2.0")
+    implementation("com.google.maps.android:maps-compose:4.0.0")
+    implementation("com.google.android.gms:play-services-maps:18.2.0")
 
     //Accompanist Permissions
     implementation("com.google.accompanist:accompanist-permissions:0.34.0")
@@ -117,7 +119,7 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.7.7")
 
     //Datastore
-    implementation ("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("androidx.datastore:datastore-preferences:1.0.0")
 
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/Place.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Place.kt
@@ -15,7 +15,7 @@ enum class Type() {
  * Data class representing a TCAT stop
  */
 @Serializable
-data class Stop(
+data class Place(
     @Json(name = "lat") var latitude: Double,
     @Json(name = "long") var longitude: Double,
     @Json(name = "name") var name: String,

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -1,7 +1,5 @@
 package com.cornellappdev.transit.models
 
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.networking.NetworkApi
 import com.google.android.gms.maps.model.LatLng
@@ -19,12 +17,12 @@ import javax.inject.Singleton
 @Singleton
 class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
 
-    suspend fun getAllStops(): Payload<List<Stop>> = networkApi.getAllStops()
+    suspend fun getAllStops(): Payload<List<Place>> = networkApi.getAllStops()
 
     private suspend fun getRoute(request: RouteRequest): Payload<RouteOptions> =
         networkApi.getRoute(request)
 
-    private val _stopFlow: MutableStateFlow<ApiResponse<List<Stop>>> =
+    private val _stopFlow: MutableStateFlow<ApiResponse<List<Place>>> =
         MutableStateFlow(ApiResponse.Pending)
 
     private val _lastRouteFlow: MutableStateFlow<ApiResponse<RouteOptions>> =

--- a/app/src/main/java/com/cornellappdev/transit/models/Stop.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Stop.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.transit.models
 
 import com.squareup.moshi.Json
+import kotlinx.serialization.Serializable
 
 /**
  * Enum class representing the types of TCAT places
@@ -13,11 +14,11 @@ enum class Type() {
 /**
  * Data class representing a TCAT stop
  */
+@Serializable
 data class Stop(
     @Json(name = "lat") var latitude: Double,
     @Json(name = "long") var longitude: Double,
     @Json(name = "name") var name: String,
     @Json(name = "detail") val detail: String?,
     @Json(name = "type") var type: Type
-
 )

--- a/app/src/main/java/com/cornellappdev/transit/models/Stop.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Stop.kt
@@ -3,11 +3,21 @@ package com.cornellappdev.transit.models
 import com.squareup.moshi.Json
 
 /**
+ * Enum class representing the types of TCAT places
+ */
+enum class Type() {
+    busStop,
+    applePlace
+}
+
+/**
  * Data class representing a TCAT stop
  */
 data class Stop(
     @Json(name = "lat") var latitude: Double,
     @Json(name = "long") var longitude: Double,
     @Json(name = "name") var name: String,
-    @Json(name = "type") var type: String
+    @Json(name = "detail") val detail: String?,
+    @Json(name = "type") var type: Type
+
 )

--- a/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
@@ -16,7 +16,6 @@ import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import javax.inject.Singleton
 import kotlinx.serialization.encodeToString
-import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.json.Json
 
 /**
@@ -50,7 +49,7 @@ class UserPreferenceRepository @Inject constructor(@ApplicationContext val conte
      * Sets favorites in user preferences
      * @param favorites: The set containing names of stops that have been favorites
      */
-    suspend fun setFavorites(favorites: Set<Stop>) {
+    suspend fun setFavorites(favorites: Set<Place>) {
         dataStore.edit { preferences ->
             val favoriteStrings = favorites.map { json.encodeToString(it) }.toSet()
             preferences[FAVORITES_MAP] = favoriteStrings
@@ -60,15 +59,15 @@ class UserPreferenceRepository @Inject constructor(@ApplicationContext val conte
     /**
      * Flow of favorite stops
      */
-    val favoritesFlow: StateFlow<Set<Stop>> = dataStore.data
+    val favoritesFlow: StateFlow<Set<Place>> = dataStore.data
         .catch {
-            setOf<Stop>()
+            setOf<Place>()
         }
         .map { preferences ->
             val favoriteStrings = preferences[FAVORITES_MAP] ?: setOf()
             val response = favoriteStrings.mapNotNull { jsonString ->
                 try {
-                    json.decodeFromString<Stop>(jsonString)
+                    json.decodeFromString<Place>(jsonString)
                 } catch (e: Exception) {
                     null
                 }

--- a/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/UserPreferenceRepository.kt
@@ -15,6 +15,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import javax.inject.Inject
 import javax.inject.Singleton
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.json.Json
 
 /**
  * Repository to store data related to user preferences
@@ -39,25 +42,37 @@ class UserPreferenceRepository @Inject constructor(@ApplicationContext val conte
     }
 
     /**
+     * Configuring serializer
+     */
+    private val json = Json { encodeDefaults = true }
+
+    /**
      * Sets favorites in user preferences
      * @param favorites: The set containing names of stops that have been favorites
      */
-    suspend fun setFavorites(favorites: Set<String>) {
+    suspend fun setFavorites(favorites: Set<Stop>) {
         dataStore.edit { preferences ->
-            preferences[FAVORITES_MAP] = favorites
+            val favoriteStrings = favorites.map { json.encodeToString(it) }.toSet()
+            preferences[FAVORITES_MAP] = favoriteStrings
         }
     }
 
     /**
      * Flow of favorite stops
      */
-    val favoritesFlow: StateFlow<Set<String>> = dataStore.data
+    val favoritesFlow: StateFlow<Set<Stop>> = dataStore.data
         .catch {
-            setOf<String>()
+            setOf<Stop>()
         }
         .map { preferences ->
-            val favorites = preferences[FAVORITES_MAP] ?: setOf<String>()
-            favorites
+            val favoriteStrings = preferences[FAVORITES_MAP] ?: setOf()
+            val response = favoriteStrings.mapNotNull { jsonString ->
+                try {
+                    json.decodeFromString<Stop>(jsonString)
+                } catch (e: Exception) {
+                    null
+                }
+            }.toSet()
+            response
         }.stateIn(CoroutineScope(Dispatchers.Default), SharingStarted.Eagerly, emptySet())
-
 }

--- a/app/src/main/java/com/cornellappdev/transit/networking/NetworkApi.kt
+++ b/app/src/main/java/com/cornellappdev/transit/networking/NetworkApi.kt
@@ -4,7 +4,7 @@ package com.cornellappdev.transit.networking
 import com.cornellappdev.transit.models.Payload
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.RouteRequest
-import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Place
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -12,7 +12,7 @@ import retrofit2.http.POST
 interface NetworkApi {
 
     @GET("/api/v1/allStops")
-    suspend fun getAllStops(): Payload<List<Stop>>
+    suspend fun getAllStops(): Payload<List<Place>>
 
     @POST("/api/v3/route")
     suspend fun getRoute(@Body request: RouteRequest): Payload<RouteOptions>

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -59,7 +59,7 @@ fun AddFavoritesSearchSheet(
     val addSearchBarValue = homeViewModel.addSearchQuery.collectAsState().value
     val addQueryResponse = homeViewModel.addQueryFlow.collectAsState().value
     var addSearchActive by remember { mutableStateOf(false) }
-    val favorites = favoritesViewModel.favoriteStops.collectAsState().value
+    val favorites = favoritesViewModel.favoritesStops.collectAsState().value
 
     Column(
         modifier = Modifier
@@ -129,7 +129,7 @@ fun AddFavoritesSearchSheet(
                             sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                             onClick = {
                                 if (!(it in favorites)) {
-                                    favoritesViewModel.addFavorite(it.name)
+                                    favoritesViewModel.addFavorite(it)
                                 }
                             }
                         )

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.cornellappdev.transit.models.Type
 import com.cornellappdev.transit.ui.theme.DividerGrey
 import com.cornellappdev.transit.ui.theme.TextButtonGray
 import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
@@ -125,9 +126,8 @@ fun AddFavoritesSearchSheet(
                         MenuItem(
                             Icons.Filled.Place,
                             label = it.name,
-                            sublabel = it.type,
+                            sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                             onClick = {
-                                //Add to favorites if not in favorites
                                 if (!(it in favorites)) {
                                     favoritesViewModel.addFavorite(it.name)
                                 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -20,7 +20,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
-import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.models.Type
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
@@ -39,7 +39,7 @@ import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 fun BottomSheetContent(
     editText: String,
     editState: Boolean,
-    data: List<Stop>,
+    data: List<Place>,
     onclick: () -> Unit,
     addOnClick: () -> Unit,
     favoritesViewModel: FavoritesViewModel = hiltViewModel(),
@@ -83,7 +83,7 @@ fun BottomSheetContent(
                     label = it.name,
                     sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                     editing = editState,
-                    { navController.navigate("route") },
+                    { navController.navigate("route/${it.name}") },
                     addOnClick = {},
                     removeOnClick = { favoritesViewModel.removeFavorite(it) },
                 )

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -85,7 +85,7 @@ fun BottomSheetContent(
                     editing = editState,
                     { navController.navigate("route") },
                     addOnClick = {},
-                    removeOnClick = { favoritesViewModel.removeFavorite(it.name) },
+                    removeOnClick = { favoritesViewModel.removeFavorite(it) },
                 )
             }
             item {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -21,6 +21,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Type
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
@@ -80,9 +81,9 @@ fun BottomSheetContent(
                     image = painterResource(id = R.drawable.location_icon),
                     editImage = painterResource(id = R.drawable.location_icon_edit),
                     label = it.name,
-                    sublabel = it.type,
+                    sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                     editing = editState,
-                    { navController.navigate("route")},
+                    { navController.navigate("route") },
                     addOnClick = {},
                     removeOnClick = { favoritesViewModel.removeFavorite(it.name) },
                 )

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -12,7 +12,7 @@ import androidx.compose.material.icons.filled.Place
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
-import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.models.Type
 
 /**
@@ -20,8 +20,8 @@ import com.cornellappdev.transit.models.Type
  */
 @Composable
 fun SearchSuggestions(
-    favorites: List<Stop>,
-    recents: List<Stop>,
+    favorites: List<Place>,
+    recents: List<Place>,
     onFavoriteAdd: () -> Unit,
     onRecentClear: () -> Unit
 ) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Type
 
 /**
  * Display for suggested searches (recents and favorites)
@@ -38,7 +39,7 @@ fun SearchSuggestions(
             MenuItem(
                 Icons.Filled.Place,
                 label = it.name,
-                sublabel = it.type,
+                sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                 onClick = {
                 })
         }
@@ -52,7 +53,7 @@ fun SearchSuggestions(
             MenuItem(
                 Icons.Filled.Place,
                 label = it.name,
-                sublabel = it.type,
+                sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                 onClick = {
                 })
         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
+import com.cornellappdev.transit.models.Type
 import com.cornellappdev.transit.ui.components.AddFavoritesSearchSheet
 import com.cornellappdev.transit.ui.components.BottomSheetContent
 import com.cornellappdev.transit.ui.components.MenuItem
@@ -192,7 +193,7 @@ fun HomeScreen(
                             MenuItem(
                                 Icons.Filled.Place,
                                 label = it.name,
-                                sublabel = it.type,
+                                sublabel = if (it.type == Type.busStop) "BusStop" else it.detail.toString(),
                                 onClick = {
                                 })
                         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -213,7 +213,7 @@ fun HomeScreen(
         mutableStateOf("Edit")
     }
 
-    val data = favoritesViewModel.favoriteStops.collectAsState().value
+    val data = favoritesViewModel.favoritesStops.collectAsState().value
 
     //sheetState for AddFavorites BottomSheet
     val addSheetState = androidx.compose.material.rememberModalBottomSheetState(
@@ -233,7 +233,7 @@ fun HomeScreen(
         sheetContent = {
             BottomSheetContent(
                 editText = txt,
-                editState = editState, data = data, onclick = {
+                editState = editState, data = data.toList(), onclick = {
                     editState = editState == false
                     txt = if (editState) {
                         "Done"

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -3,14 +3,9 @@ package com.cornellappdev.transit.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.RouteRepository
+import com.cornellappdev.transit.models.Stop
 import com.cornellappdev.transit.models.UserPreferenceRepository
-import com.cornellappdev.transit.networking.ApiResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -24,47 +19,16 @@ class FavoritesViewModel @Inject constructor(
 ) : ViewModel() {
 
     /**
-     * A flow emitting all the locations and whether or not they have been favorited.
-     */
-    private val favoritesFlow = userPreferenceRepository.favoritesFlow
-    //private val favoritesFlow: StateFlow<Set<String>> = MutableStateFlow(setOf("Gates Hall", "Duffield")).asStateFlow()
-
-    /**
-     * Flow of all TCAT stops
-     */
-    private val stopFlow = routeRepository.stopFlow
-
-    private val scope = CoroutineScope(Dispatchers.Default)
-
-    /**
      * A flow emitting all the locations the user has favorited as a list of stops.
      */
-    val favoriteStops = stopFlow.combine(
-        favoritesFlow
-    ) { apiResponse, favorites ->
-        when (apiResponse) {
-            is ApiResponse.Error -> {
-                emptyList()
-            }
-
-            is ApiResponse.Pending -> {
-                emptyList()
-            }
-
-            is ApiResponse.Success -> {
-                apiResponse.data.filter { stop ->
-                    favorites.contains(stop.name)
-                }
-            }
-        }
-    }.stateIn(scope, SharingStarted.Eagerly, emptyList())
+    val favoritesStops = userPreferenceRepository.favoritesFlow
 
     /**
      * Asynchronous function to remove a stop from favorites
      */
-    fun removeFavorite(stop: String?) {
+    fun removeFavorite(stop: Stop?) {
         if (stop != null) {
-            val currentFavorites = favoritesFlow.value.toMutableSet()
+            val currentFavorites = favoritesStops.value.toMutableSet()
             currentFavorites.remove(stop)
             viewModelScope.launch {
                 userPreferenceRepository.setFavorites(currentFavorites.toSet())
@@ -75,9 +39,9 @@ class FavoritesViewModel @Inject constructor(
     /**
      * Asynchronous function to add a stop to favorites
      */
-    fun addFavorite(stop: String?) {
+    fun addFavorite(stop: Stop?) {
         if (stop != null) {
-            val currentFavorites = favoritesFlow.value.toMutableSet()
+            val currentFavorites = favoritesStops.value.toMutableSet()
             currentFavorites.add(stop)
             viewModelScope.launch {
                 userPreferenceRepository.setFavorites(currentFavorites.toSet())

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/FavoritesViewModel.kt
@@ -3,7 +3,7 @@ package com.cornellappdev.transit.ui.viewmodels
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.RouteRepository
-import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.launch
@@ -26,7 +26,7 @@ class FavoritesViewModel @Inject constructor(
     /**
      * Asynchronous function to remove a stop from favorites
      */
-    fun removeFavorite(stop: Stop?) {
+    fun removeFavorite(stop: Place?) {
         if (stop != null) {
             val currentFavorites = favoritesStops.value.toMutableSet()
             currentFavorites.remove(stop)
@@ -39,7 +39,7 @@ class FavoritesViewModel @Inject constructor(
     /**
      * Asynchronous function to add a stop to favorites
      */
-    fun addFavorite(stop: Stop?) {
+    fun addFavorite(stop: Place?) {
         if (stop != null) {
             val currentFavorites = favoritesStops.value.toMutableSet()
             currentFavorites.add(stop)

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -2,27 +2,15 @@ package com.cornellappdev.transit.ui.viewmodels
 
 import android.content.Context
 import android.util.Log
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
 import com.cornellappdev.transit.models.RouteRepository
-import com.cornellappdev.transit.models.Stop
-import com.cornellappdev.transit.networking.ApiResponse
-import com.google.android.gms.location.FusedLocationProviderClient
+import com.cornellappdev.transit.models.Place
 import com.google.android.gms.maps.model.LatLng
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -85,7 +73,7 @@ class HomeViewModel @Inject constructor(
     /**
      * True if the stop can be searched via the [query] string
      */
-    private fun fulfillsQuery(stop: Stop, query: String): Boolean {
+    private fun fulfillsQuery(stop: Place, query: String): Boolean {
         return !query.isBlank() && stop.name.lowercase().contains(query.lowercase())
     }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -1,23 +1,10 @@
 package com.cornellappdev.transit.ui.viewmodels
 
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.SheetState
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
-import com.cornellappdev.transit.models.Route
 import com.cornellappdev.transit.models.RouteRepository
-import com.cornellappdev.transit.models.Stop
-import com.cornellappdev.transit.networking.ApiResponse
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/SearchUtils.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/SearchUtils.kt
@@ -2,15 +2,12 @@ package com.cornellappdev.transit.ui.viewmodels
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import com.cornellappdev.transit.models.Stop
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.networking.ApiResponse
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.coroutineContext
 import kotlinx.coroutines.flow.stateIn
 
 /**
@@ -21,7 +18,7 @@ object SearchUtils {
     /**
      * True if the stop can be searched via the [query] string
      */
-    fun fulfillsQuery(stop: Stop, query: String): Boolean {
+    fun fulfillsQuery(stop: Place, query: String): Boolean {
         return !query.isBlank() && stop.name.lowercase().contains(query.lowercase())
     }
 
@@ -37,9 +34,9 @@ object SearchUtils {
  */
 fun ViewModel.createStopQueryFlow(
     searchQuery: MutableStateFlow<String>,
-    stopFlow: StateFlow<ApiResponse<List<Stop>>>,
-    fulfillsQuery: (Stop, String) -> Boolean = SearchUtils::fulfillsQuery,
-): StateFlow<List<Stop>> =
+    stopFlow: StateFlow<ApiResponse<List<Place>>>,
+    fulfillsQuery: (Place, String) -> Boolean = SearchUtils::fulfillsQuery,
+): StateFlow<List<Place>> =
     stopFlow.combine(searchQuery) { allStops, filter ->
         when (allStops) {
             is ApiResponse.Error -> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,4 +12,5 @@ plugins {
     id("com.android.application") version "8.1.1" apply false
     id("org.jetbrains.kotlin.android") version "1.9.0" apply false
     id("com.google.dagger.hilt.android") version "2.50" apply false
+    id("org.jetbrains.kotlin.plugin.serialization") version "1.6.21"
 }


### PR DESCRIPTION
- Changed Stop Type from String -> Enum
- Changed Stop class to add a nullable details field, since applePlaces have a details field but busStops don't
- Changed the type of Favorites from String -> Stop
   - Added serialization to userpreferences to store the Stop set in DataStore
   - removed combining the flows in favoritesViewModel