### PR TITLE
Mihilih/bottom sheet fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/Place.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Place.kt
@@ -10,8 +10,8 @@ data class SearchQuery(
 )
 
 data class QueryResult(
-    @Json(name = "applePlaces") var places: List<Place>,
-    @Json(name = "busStops") var stops: List<Place>
+    @Json(name = "applePlaces") var places: List<Place>?,
+    @Json(name = "busStops") var stops: List<Place>?
 )
 
 /**

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.transit.models
 
+import android.util.Log
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.networking.NetworkApi
 import com.google.android.gms.maps.model.LatLng
@@ -78,7 +79,7 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
             try {
                 val placeResponse = appleSearch(SearchQuery(query))
                 val res = placeResponse.unwrap()
-                val totalLocations = res.places + res.stops
+                val totalLocations = (res.places ?: emptyList()) + (res.stops?: (emptyList()))
                 _placeFlow.value = ApiResponse.Success(totalLocations)
             } catch (e: Exception) {
                 _placeFlow.value = ApiResponse.Error

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Place
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.DockedSearchBar
@@ -30,6 +29,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -42,6 +42,7 @@ import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
 import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
+
 
 /**
  * Contents of AddFavorites BottomSheet
@@ -63,6 +64,9 @@ fun AddFavoritesSearchSheet(
     var addSearchActive by remember { mutableStateOf(false) }
 
     val favorites = favoritesViewModel.favoritesStops.collectAsState().value
+
+    val keyboardController = LocalSoftwareKeyboardController.current
+
 
     Column(
         modifier = Modifier
@@ -92,7 +96,10 @@ fun AddFavoritesSearchSheet(
                         modifier = Modifier.align(Alignment.Center)
                     )
                     TextButton(
-                        onClick = onClick,
+                        onClick = {
+                            onClick()
+                            keyboardController?.hide()
+                        },
                         content = {
                             Text(
                                 text = "Cancel",
@@ -145,6 +152,7 @@ fun AddFavoritesSearchSheet(
                                     onClick = {
                                         if (it !in favorites) {
                                             favoritesViewModel.addFavorite(it)
+                                            keyboardController?.hide()
                                         }
                                     })
                             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -53,7 +53,7 @@ import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 fun AddFavoritesSearchSheet(
     homeViewModel: HomeViewModel,
     favoritesViewModel: FavoritesViewModel,
-    cancelOnClick: () -> Unit,
+    onClick: () -> Unit,
 ) {
 
     val addSearchBarValue = homeViewModel.addSearchQuery.collectAsState().value
@@ -92,7 +92,7 @@ fun AddFavoritesSearchSheet(
                         modifier = Modifier.align(Alignment.Center)
                     )
                     TextButton(
-                        onClick = cancelOnClick,
+                        onClick = onClick,
                         content = {
                             Text(
                                 text = "Cancel",

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -84,7 +84,9 @@ fun BottomSheetContent(
                     editing = editState,
                     { navController.navigate("route/${it.name}") },
                     addOnClick = {},
-                    removeOnClick = { favoritesViewModel.removeFavorite(it) },
+                    removeOnClick = {
+                        favoritesViewModel.removeFavorite(it)
+                    },
                 )
             }
             item {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -41,10 +41,11 @@ fun BottomSheetContent(
     data: List<Place>,
     onclick: () -> Unit,
     addOnClick: () -> Unit,
+    removeOnClick: (Place) -> Unit,
     favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     navController: NavController
 ) {
-    Column() {
+    Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -84,9 +85,7 @@ fun BottomSheetContent(
                     editing = editState,
                     { navController.navigate("route/${it.name}") },
                     addOnClick = {},
-                    removeOnClick = {
-                        favoritesViewModel.removeFavorite(it)
-                    },
+                    removeOnClick = { removeOnClick(it) },
                 )
             }
             item {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -13,8 +13,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ExperimentalMaterialApi
-import androidx.compose.material.ModalBottomSheetLayout
-import androidx.compose.material.ModalBottomSheetValue
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
@@ -199,11 +197,9 @@ fun HomeScreen(
                         LazyColumn {
                             when (searchBarValue.searched) {
                                 is ApiResponse.Error -> {
-
                                 }
 
                                 is ApiResponse.Pending -> {
-
                                 }
 
                                 is ApiResponse.Success -> {
@@ -217,6 +213,10 @@ fun HomeScreen(
                                                 navController.navigate("route/${it.name}")
                                             })
 
+                                    }
+                                    if (searchBarValue.searched.data.isEmpty()) {
+                                        //TODO: change temp fix
+                                        item { Text("No search results") }
                                     }
                                 }
                             }
@@ -232,8 +232,6 @@ fun HomeScreen(
         bottomSheetState = SheetState(
             skipPartiallyExpanded = false,
             initialValue = SheetValue.PartiallyExpanded,
-            confirmValueChange = { true },
-            skipHiddenState = true
         )
     )
 
@@ -247,12 +245,11 @@ fun HomeScreen(
     val data = favoritesViewModel.favoritesStops.collectAsState().value
 
     //sheetState for AddFavorites BottomSheet
-    val addSheetState = androidx.compose.material.rememberModalBottomSheetState(
-        ModalBottomSheetValue.Hidden,
-        skipHalfExpanded = true,
-        confirmValueChange = {
-            true
-        }
+    val addSheetState = rememberBottomSheetScaffoldState(
+        bottomSheetState = SheetState(
+            skipPartiallyExpanded = true,
+            initialValue = SheetValue.Hidden
+        )
     )
 
     val scope = rememberCoroutineScope()
@@ -275,27 +272,32 @@ fun HomeScreen(
                     }
                 }, addOnClick = {
                     scope.launch {
-                        addSheetState.show()
+                        addSheetState.bottomSheetState.expand()
                     }
-                }, navController = navController
+                },
+                navController = navController
             )
         }
     ) {}
+    //TODO: fix favorites closing when there's a change
 
     // AddFavorites BottomSheet
-    ModalBottomSheetLayout(
+    BottomSheetScaffold(
         sheetShape = RoundedCornerShape(16.dp),
-        sheetBackgroundColor = Color.White,
-        sheetState = addSheetState,
+        scaffoldState = addSheetState,
+        sheetContainerColor = Color.White,
+        sheetPeekHeight = 0.dp,
         sheetContent = {
             AddFavoritesSearchSheet(
                 homeViewModel = homeViewModel,
                 favoritesViewModel = favoritesViewModel
             ) {
                 scope.launch {
-                    addSheetState.hide()
+                    addSheetState.bottomSheetState.hide()
                 }
             }
         },
-    ) {}
+
+        ) {}
+    //TODO: Fix keyboard
 }


### PR DESCRIPTION
- FavoritesBottomsheet does not close when the content changes (Set initial state to expanded and make sure to expand whenever there's a change in content) Closes #31 
- AddFavoritesBottomSheet closes when a favorite is added. Closes #32 
- Fix Search Error where the search returns `ApiResponse.Error` when a character is added to the current query. Made `places` and `stops` nullable in `QueryResult`. Closes #37 
- Made sure the keyboard closes after AddFavoritesBottomSheet closes. 