### PR TITLE
Navigating form Route Options to Route Details

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/MapState.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/MapState.kt
@@ -11,5 +11,6 @@ enum class RouteOptionType {
 
 data class MapState(
     val isShowing: Boolean,
-    val routeOptionType: RouteOptionType
+    val routeOptionType: RouteOptionType,
+    val route: Route?
 )

--- a/app/src/main/java/com/cornellappdev/transit/models/MapState.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/MapState.kt
@@ -11,6 +11,5 @@ enum class RouteOptionType {
 
 data class MapState(
     val isShowing: Boolean,
-    val routeOptionType: RouteOptionType,
     val route: Route?
 )

--- a/app/src/main/java/com/cornellappdev/transit/models/Route.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Route.kt
@@ -26,7 +26,7 @@ data class Direction(
     @Json(name = "endLocation") val endLocation: LatLng,
     @Json(name = "routeId") val routeId: String?,
     @Json(name = "tripIds") val tripIds: List<String>?,
-    @Json(name = "stayOnBusForTransfer") val stayOnBusForTransfer: Boolean,
+    @Json(name = "stayOnBusForTransfer") val stayOnBusForTransfer: Boolean?,
     @Json(name = "delay") val delay: Int?,
     @Json(name = "startLocation") val startLocation: LatLng,
     @Json(name = "path") val path: List<LatLng>,
@@ -59,9 +59,9 @@ data class Route(
  * Data class wrapping all possible routes from a given start and end
  */
 data class RouteOptions(
-    @Json(name = "boardingSoon") val boardingSoon: List<Route>,
-    @Json(name = "fromStop") val fromStop: List<Route>,
-    @Json(name = "walking") val walking: List<Route>
+    @Json(name = "boardingSoon") val boardingSoon: List<Route>?,
+    @Json(name = "fromStop") val fromStop: List<Route>?,
+    @Json(name = "walking") val walking: List<Route>?
 )
 
 /**

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -121,7 +121,6 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
                 _lastRouteFlow.value = ApiResponse.Success(routeResponse.unwrap())
             } catch (e: Exception) {
                 _lastRouteFlow.value = ApiResponse.Error
-                Log.e("helpme", e.toString())
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -79,7 +79,7 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
             try {
                 val placeResponse = appleSearch(SearchQuery(query))
                 val res = placeResponse.unwrap()
-                val totalLocations = (res.places ?: emptyList()) + (res.stops?: (emptyList()))
+                val totalLocations = (res.places ?: emptyList()) + (res.stops ?: (emptyList()))
                 _placeFlow.value = ApiResponse.Success(totalLocations)
             } catch (e: Exception) {
                 _placeFlow.value = ApiResponse.Error
@@ -121,6 +121,7 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
                 _lastRouteFlow.value = ApiResponse.Success(routeResponse.unwrap())
             } catch (e: Exception) {
                 _lastRouteFlow.value = ApiResponse.Error
+                Log.e("helpme", e.toString())
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -16,7 +16,6 @@ import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
 import com.cornellappdev.transit.util.StringUtils.fromURLString
 import com.google.android.gms.maps.model.LatLng
-import kotlin.math.log
 
 /**
  * The navigation controller for the app (parent of all screens)
@@ -60,7 +59,10 @@ fun NavigationController(
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
         composable("details") {
-            DetailsScreen(navController = navController, homeViewModel = homeViewModel)
+            DetailsScreen(
+                navController = navController,
+                routeViewModel = routeViewModel,
+            )
         }
 
         composable("route") {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.theme.TextButtonGray
@@ -53,7 +54,7 @@ import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 @Composable
 fun AddFavoritesSearchSheet(
     homeViewModel: HomeViewModel,
-    favoritesViewModel: FavoritesViewModel,
+    favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     cancelOnClick: () -> Unit,
 ) {
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
-import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
@@ -89,7 +88,7 @@ fun BottomSheetContent(
                     editing = editState,
                     { navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}") },
                     addOnClick = {},
-                    removeOnClick = {favoritesViewModel.removeFavorite(it); removeOnClick()},
+                    removeOnClick = { favoritesViewModel.removeFavorite(it); removeOnClick() },
                 )
             }
             item {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -39,13 +40,15 @@ import com.cornellappdev.transit.util.StringUtils.toURLString
 fun BottomSheetContent(
     editText: String,
     editState: Boolean,
-    data: List<Place>,
     onclick: () -> Unit,
     addOnClick: () -> Unit,
-    removeOnClick: (Place) -> Unit,
+    removeOnClick: () -> Unit,
     favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     navController: NavController
 ) {
+
+    val data = favoritesViewModel.favoritesStops.collectAsState().value.toList()
+
     Column {
         Row(
             modifier = Modifier
@@ -86,7 +89,7 @@ fun BottomSheetContent(
                     editing = editState,
                     { navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}") },
                     addOnClick = {},
-                    removeOnClick = { removeOnClick(it) },
+                    removeOnClick = {favoritesViewModel.removeFavorite(it); removeOnClick()},
                 )
             }
             item {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -42,7 +42,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.networking.ApiResponse
@@ -51,9 +50,7 @@ import com.cornellappdev.transit.ui.components.BottomSheetContent
 import com.cornellappdev.transit.ui.components.MenuItem
 import com.cornellappdev.transit.ui.components.SearchSuggestions
 import com.cornellappdev.transit.ui.theme.DividerGray
-import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
-import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
 import com.cornellappdev.transit.util.StringUtils.toURLString
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
@@ -77,7 +74,6 @@ import kotlinx.coroutines.launch
 fun HomeScreen(
     homeViewModel: HomeViewModel,
     navController: NavController,
-    favoritesViewModel: FavoritesViewModel = hiltViewModel()
 ) {
     // Permissions dialog
     val permissionState = rememberPermissionState(android.Manifest.permission.ACCESS_FINE_LOCATION)
@@ -250,7 +246,6 @@ fun HomeScreen(
 
     val scope = rememberCoroutineScope()
 
-    val data = favoritesViewModel.favoritesStops.collectAsState().value
 
     // Favorites BottomSheet
     BottomSheetScaffold(
@@ -262,7 +257,6 @@ fun HomeScreen(
             BottomSheetContent(
                 editText = editText,
                 editState = editState,
-                data = data.toList(),
                 onclick = {
                     editState = !editState
                     editText = if (editState) {
@@ -281,8 +275,7 @@ fun HomeScreen(
                         addSheetState.bottomSheetState.expand()
                     }
                 },
-                removeOnClick = { place ->
-                    favoritesViewModel.removeFavorite(place)
+                removeOnClick = {
                     scope.launch {
                         favoritesSheetState.bottomSheetState.expand()
                     }
@@ -301,7 +294,6 @@ fun HomeScreen(
         sheetContent = {
             AddFavoritesSearchSheet(
                 homeViewModel = homeViewModel,
-                favoritesViewModel = favoritesViewModel
             ) {
                 scope.launch {
                     addSheetState.bottomSheetState.hide()

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -76,7 +76,6 @@ import kotlinx.coroutines.launch
 @Composable
 fun HomeScreen(
     homeViewModel: HomeViewModel,
-    routeViewModel: RouteViewModel = hiltViewModel(),
     navController: NavController,
     favoritesViewModel: FavoritesViewModel = hiltViewModel()
 ) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -135,9 +135,6 @@ fun HomeScreen(
         position = CameraPosition.fromLatLngZoom(homeViewModel.defaultIthaca, 12f)
     }
 
-    //Map state
-    val mapState = homeViewModel.mapState.collectAsState().value
-
     // Search bar active/inactive
     var searchActive by remember { mutableStateOf(false) }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -50,6 +50,9 @@ import androidx.compose.ui.unit.sp
 import androidx.constraintlayout.compose.ConstraintLayout
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
+import com.cornellappdev.transit.models.MapState
+import com.cornellappdev.transit.models.Route
+import com.cornellappdev.transit.models.RouteOptionType
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.Transport
 import com.cornellappdev.transit.models.toTransport
@@ -159,7 +162,7 @@ fun RouteScreen(
                 lastRoute = lastRoute,
                 startSheetState = startSheetState,
                 destSheetState = destSheetState
-            )
+            ) { routeOptionsType, transport -> routeViewModel.setMapState(MapState(true, routeOptionsType, transport)) ;navController.navigate("details") }
         }
     }
 
@@ -179,7 +182,8 @@ private fun RouteOptionsMainMenu(
     endLocation: LocationUIState,
     lastRoute: ApiResponse<RouteOptions>,
     startSheetState: ModalBottomSheetState,
-    destSheetState: ModalBottomSheetState
+    destSheetState: ModalBottomSheetState,
+    onClick: (RouteOptionType, Route) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -365,8 +369,7 @@ private fun RouteOptionsMainMenu(
                 color = MetadataGray, fontSize = 14.sp
             )
         }
-
-        RouteList(lastRoute)
+        RouteList(lastRoute, onClick)
     }
 }
 
@@ -374,8 +377,10 @@ private fun RouteOptionsMainMenu(
  * Route cell with padding
  */
 @Composable
-private fun PaddedRouteCell(transport: Transport) {
-    Row(modifier = Modifier.padding(12.dp)) {
+private fun PaddedRouteCell(transport: Transport, onClick: () -> Unit) {
+    Row(modifier = Modifier
+        .padding(12.dp)
+        .clickable { onClick() }) {
         RouteCell(transport)
     }
 }
@@ -385,7 +390,10 @@ private fun PaddedRouteCell(transport: Transport) {
  */
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-private fun RouteList(lastRouteResponse: ApiResponse<RouteOptions>) {
+private fun RouteList(
+    lastRouteResponse: ApiResponse<RouteOptions>,
+    onClick: (RouteOptionType, Route) -> Unit
+) {
     when (lastRouteResponse) {
         is ApiResponse.Error -> {
             Text("Error")
@@ -396,14 +404,17 @@ private fun RouteList(lastRouteResponse: ApiResponse<RouteOptions>) {
         }
 
         is ApiResponse.Success -> {
-
-            LazyColumn(modifier = Modifier
-                .background(color = DividerGray)
-                .fillMaxSize(), content = {
-                items(lastRouteResponse.data.fromStop, itemContent = { item ->
-                    PaddedRouteCell(item.toTransport())
-                })
-                if (lastRouteResponse.data.boardingSoon.isNotEmpty()) {
+            LazyColumn(
+                modifier = Modifier
+                    .background(color = DividerGray)
+                    .fillMaxSize()
+            ) {
+                lastRouteResponse.data.fromStop?.let {
+                    items(it) { item ->
+                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.FromStop, item) }
+                    }
+                }
+                if (lastRouteResponse.data.boardingSoon?.isNotEmpty() == true) {
                     item {
                         Text(
                             "Boarding Soon From Nearby Stops",
@@ -411,15 +422,17 @@ private fun RouteList(lastRouteResponse: ApiResponse<RouteOptions>) {
                             color = MetadataGray,
                             modifier = Modifier.padding(
                                 start = 12.dp,
-                                top = if (lastRouteResponse.data.fromStop.isEmpty()) 12.dp else 0.dp
+                                top = if (lastRouteResponse.data.fromStop?.isEmpty() == true) 12.dp else 0.dp
                             )
                         )
                     }
                 }
-                items(lastRouteResponse.data.boardingSoon, itemContent = { item ->
-                    PaddedRouteCell(item.toTransport())
-                })
-                if (lastRouteResponse.data.walking.isNotEmpty()) {
+                lastRouteResponse.data.boardingSoon?.let {
+                    items(it) { item ->
+                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.BoardingSoon, item) }
+                    }
+                }
+                if (lastRouteResponse.data.walking?.isNotEmpty() == true) {
                     item {
                         Text(
                             "By Walking",
@@ -427,15 +440,17 @@ private fun RouteList(lastRouteResponse: ApiResponse<RouteOptions>) {
                             color = MetadataGray,
                             modifier = Modifier.padding(
                                 start = 12.dp,
-                                top = if (lastRouteResponse.data.boardingSoon.isEmpty()) 12.dp else 0.dp
+                                top = if (lastRouteResponse.data.boardingSoon?.isEmpty() == true) 12.dp else 0.dp
                             )
                         )
                     }
                 }
-                items(lastRouteResponse.data.walking, itemContent = { item ->
-                    PaddedRouteCell(item.toTransport())
-                })
-            })
+                lastRouteResponse.data.walking?.let {
+                    items(it) { item ->
+                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.Walking, item) }
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -52,7 +52,6 @@ import androidx.navigation.NavController
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.models.MapState
 import com.cornellappdev.transit.models.Route
-import com.cornellappdev.transit.models.RouteOptionType
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.Transport
 import com.cornellappdev.transit.models.toTransport
@@ -162,12 +161,11 @@ fun RouteScreen(
                 lastRoute = lastRoute,
                 startSheetState = startSheetState,
                 destSheetState = destSheetState
-            ) { routeOptionsType, transport ->
+            ) { route ->
                 routeViewModel.setMapState(
                     MapState(
                         true,
-                        routeOptionsType,
-                        transport
+                        route
                     )
                 );navController.navigate("details")
             }
@@ -191,7 +189,7 @@ private fun RouteOptionsMainMenu(
     lastRoute: ApiResponse<RouteOptions>,
     startSheetState: ModalBottomSheetState,
     destSheetState: ModalBottomSheetState,
-    onClick: (RouteOptionType, Route) -> Unit
+    onClick: (Route) -> Unit
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         TopAppBar(
@@ -400,7 +398,7 @@ private fun PaddedRouteCell(transport: Transport, onClick: () -> Unit) {
 @Composable
 private fun RouteList(
     lastRouteResponse: ApiResponse<RouteOptions>,
-    onClick: (RouteOptionType, Route) -> Unit
+    onClick: (Route) -> Unit
 ) {
     when (lastRouteResponse) {
         is ApiResponse.Error -> {
@@ -421,7 +419,6 @@ private fun RouteList(
                     items(it) { item ->
                         PaddedRouteCell(item.toTransport()) {
                             onClick(
-                                RouteOptionType.FromStop,
                                 item
                             )
                         }
@@ -444,7 +441,6 @@ private fun RouteList(
                     items(it) { item ->
                         PaddedRouteCell(item.toTransport()) {
                             onClick(
-                                RouteOptionType.BoardingSoon,
                                 item
                             )
                         }
@@ -467,7 +463,6 @@ private fun RouteList(
                     items(it) { item ->
                         PaddedRouteCell(item.toTransport()) {
                             onClick(
-                                RouteOptionType.Walking,
                                 item
                             )
                         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -162,7 +162,15 @@ fun RouteScreen(
                 lastRoute = lastRoute,
                 startSheetState = startSheetState,
                 destSheetState = destSheetState
-            ) { routeOptionsType, transport -> routeViewModel.setMapState(MapState(true, routeOptionsType, transport)) ;navController.navigate("details") }
+            ) { routeOptionsType, transport ->
+                routeViewModel.setMapState(
+                    MapState(
+                        true,
+                        routeOptionsType,
+                        transport
+                    )
+                );navController.navigate("details")
+            }
         }
     }
 
@@ -411,7 +419,12 @@ private fun RouteList(
             ) {
                 lastRouteResponse.data.fromStop?.let {
                     items(it) { item ->
-                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.FromStop, item) }
+                        PaddedRouteCell(item.toTransport()) {
+                            onClick(
+                                RouteOptionType.FromStop,
+                                item
+                            )
+                        }
                     }
                 }
                 if (lastRouteResponse.data.boardingSoon?.isNotEmpty() == true) {
@@ -429,7 +442,12 @@ private fun RouteList(
                 }
                 lastRouteResponse.data.boardingSoon?.let {
                     items(it) { item ->
-                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.BoardingSoon, item) }
+                        PaddedRouteCell(item.toTransport()) {
+                            onClick(
+                                RouteOptionType.BoardingSoon,
+                                item
+                            )
+                        }
                     }
                 }
                 if (lastRouteResponse.data.walking?.isNotEmpty() == true) {
@@ -447,7 +465,12 @@ private fun RouteList(
                 }
                 lastRouteResponse.data.walking?.let {
                     items(it) { item ->
-                        PaddedRouteCell(item.toTransport()) { onClick(RouteOptionType.Walking, item) }
+                        PaddedRouteCell(item.toTransport()) {
+                            onClick(
+                                RouteOptionType.Walking,
+                                item
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -5,9 +5,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
-import com.cornellappdev.transit.models.MapState
 import com.cornellappdev.transit.models.Place
-import com.cornellappdev.transit.models.RouteOptionType
 import com.cornellappdev.transit.models.RouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
@@ -184,21 +182,5 @@ class HomeViewModel @Inject constructor(
     fun instantiateLocation(context: Context) {
         locationRepository.instantiate(context)
     }
-
-    // Map state
-
-    /**
-     * Emits whether a route should be showing on the map
-     */
-    val mapState: MutableStateFlow<MapState> =
-        MutableStateFlow(MapState(isShowing = false, routeOptionType = RouteOptionType.None))
-
-    /**
-     * Set map state for home screen
-     */
-    fun setMapState(value: MapState) {
-        mapState.value = value
-    }
-
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -6,7 +6,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
 import com.cornellappdev.transit.models.MapState
-import com.cornellappdev.transit.models.RouteOptionType
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.RouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
@@ -226,7 +225,6 @@ class RouteViewModel @Inject constructor(
         MutableStateFlow(
             MapState(
                 isShowing = false,
-                routeOptionType = RouteOptionType.None,
                 route = null
             )
         )

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -5,6 +5,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
+import com.cornellappdev.transit.models.MapState
+import com.cornellappdev.transit.models.RouteOptionType
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.RouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
@@ -61,6 +63,11 @@ class RouteViewModel @Inject constructor(
     val time = "12:00AM"
 
     val lastRouteFlow: StateFlow<ApiResponse<RouteOptions>> = routeRepository.lastRouteFlow
+
+    /**
+     * Default map location
+     */
+    val defaultIthaca = LatLng(42.44, -76.50)
 
     /**
      * The current UI state of the search bar, as a MutableStateFlow
@@ -209,6 +216,26 @@ class RouteViewModel @Inject constructor(
                 originName = originName
             )
         }
+    }
+
+
+    /**
+     * Emits whether a route should be showing on the map
+     */
+    val mapState: MutableStateFlow<MapState> =
+        MutableStateFlow(
+            MapState(
+                isShowing = false,
+                routeOptionType = RouteOptionType.None,
+                route = null
+            )
+        )
+
+    /**
+     * Set map state for home screen
+     */
+    fun setMapState(value: MapState) {
+        mapState.value = value
     }
 
 }


### PR DESCRIPTION
- Add navigation from `RouteScreen` to `DetailsScreen` with `mapState` containing the selected route
- Modified `DrawableMap` to only draw the selected route
- Refactored `HomeScreen` to remove `RouteViewModel` and `FavoritesViewModel`
- Bug fixes with the networking call for routeOptions

https://github.com/user-attachments/assets/350000bf-6abb-4aad-8fd4-3b8eb0cddbb4