### PR TITLE
Update Compose version and start route details bottom sheet

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("kotlin-kapt")
     id("com.google.dagger.hilt.android")
     id("kotlinx-serialization")
+    id("org.jetbrains.kotlin.plugin.compose") version "2.0.0"
 }
 
 secrets {
@@ -63,42 +64,42 @@ android {
 
 dependencies {
     implementation("androidx.core:core-ktx:1.12.0")
-    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
-    implementation("androidx.activity:activity-compose:1.8.2")
-    implementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.activity:activity-compose:1.9.3")
+    implementation(platform("androidx.compose:compose-bom:2024.11.00"))
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-graphics")
     implementation("androidx.compose.ui:ui-tooling-preview")
-    implementation("androidx.compose.material:material:1.6.5")
+    implementation("androidx.compose.material:material:1.7.5")
     implementation("androidx.compose.material3:material3")
-    implementation("com.google.android.gms:play-services-location:21.1.0")
-    implementation("androidx.compose.material3:material3:1.1.0-alpha02")
-    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("com.google.android.gms:play-services-location:21.3.0")
+    implementation("androidx.compose.material3:material3:1.3.1")
+    implementation("androidx.constraintlayout:constraintlayout:2.2.0")
     implementation("androidx.media3:media3-common:1.3.0")
     testImplementation("junit:junit:4.13.2")
-    androidTestImplementation("androidx.test.ext:junit:1.1.5")
-    androidTestImplementation("androidx.test.espresso:espresso-core:3.5.1")
-    androidTestImplementation(platform("androidx.compose:compose-bom:2023.03.00"))
+    androidTestImplementation("androidx.test.ext:junit:1.2.1")
+    androidTestImplementation("androidx.test.espresso:espresso-core:3.6.1")
+    androidTestImplementation(platform("androidx.compose:compose-bom:2024.11.00"))
     androidTestImplementation("androidx.compose.ui:ui-test-junit4")
     debugImplementation("androidx.compose.ui:ui-tooling")
     debugImplementation("androidx.compose.ui:ui-test-manifest")
-    implementation("androidx.constraintlayout:constraintlayout-compose:1.0.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4")
+    implementation("androidx.constraintlayout:constraintlayout-compose:1.1.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.6.0")
 
     //Maps
     implementation("com.google.maps.android:maps-compose:4.0.0")
-    implementation("com.google.android.gms:play-services-maps:18.2.0")
+    implementation("com.google.android.gms:play-services-maps:19.0.0")
 
     //Accompanist Permissions
     implementation("com.google.accompanist:accompanist-permissions:0.34.0")
 
-    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.7.0")
-    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0-alpha01")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.7")
 
     // OkHTTP
-    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.10.0"))
+    implementation(platform("com.squareup.okhttp3:okhttp-bom:4.12.0"))
     implementation("com.squareup.okhttp3:okhttp")
     implementation("com.squareup.okhttp3:logging-interceptor")
 
@@ -113,15 +114,19 @@ dependencies {
     kapt("com.google.dagger:hilt-android-compiler:2.50")
 
     //Navigation
-    implementation("androidx.hilt:hilt-navigation-fragment:1.1.0")
-    implementation("androidx.hilt:hilt-navigation-compose:1.2.0-rc01")
-    implementation("androidx.navigation:navigation-compose:2.7.7")
+    implementation("androidx.hilt:hilt-navigation-fragment:1.2.0")
+    implementation("androidx.hilt:hilt-navigation-compose:1.2.0")
+    implementation("androidx.navigation:navigation-compose:2.8.4")
 
     //Datastore
-    implementation("androidx.datastore:datastore-preferences:1.0.0")
+    implementation("androidx.datastore:datastore-preferences:1.1.1")
 
     //Datetime
     implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.3.0")
+
+    //Bottomsheet
+    implementation("io.morfly.compose:advanced-bottomsheet-material3:0.1.0")
+
 
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/Route.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Route.kt
@@ -35,6 +35,7 @@ data class Direction(
     @Json(name = "endTime") val endTime: String,
     @Json(name = "distance") val distance: String,
     @Json(name = "startTime") val startTime: String,
+    @Json(name = "name") val name: String
 ) {
     val type
         get() = if (directionType == "walk") DirectionType.WALK else DirectionType.DEPART

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/DetailsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/DetailsScreen.kt
@@ -1,8 +1,12 @@
 package com.cornellappdev.transit.ui.screens
 
 import android.Manifest
+import android.os.Build
+import androidx.annotation.RequiresApi
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
 import androidx.compose.material3.Divider
@@ -32,11 +36,17 @@ import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
 import com.google.maps.android.compose.rememberCameraPositionState
+import io.morfly.compose.bottomsheet.material3.BottomSheetScaffold
+import io.morfly.compose.bottomsheet.material3.rememberBottomSheetScaffoldState
+import io.morfly.compose.bottomsheet.material3.rememberBottomSheetState
 
 /**
  * Screen for showing a particular route
  */
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
+@RequiresApi(Build.VERSION_CODES.O)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class,
+    ExperimentalFoundationApi::class
+)
 @Composable
 fun DetailsScreen(navController: NavHostController, routeViewModel: RouteViewModel) {
 
@@ -50,33 +60,57 @@ fun DetailsScreen(navController: NavHostController, routeViewModel: RouteViewMod
     //Map state
     val mapState = routeViewModel.mapState.collectAsState().value
 
+    // Using advanced-bottomsheet-compose from https://github.com/Morfly/advanced-bottomsheet-compose
+    val sheetState = rememberBottomSheetState(
+        initialValue = SheetValue.PartiallyExpanded,
+        defineValues = {
+            // Bottom sheet height is 100 dp.
+            SheetValue.Collapsed at height(100.dp)
+            // Bottom sheet offset is 60%, meaning it takes 40% of the screen.
+            SheetValue.PartiallyExpanded at offset(percent = 60)
+            // Bottom sheet height is equal to its content height.
+            SheetValue.Expanded at contentHeight
+        }
+    )
 
-    Column(modifier = Modifier.fillMaxSize()) {
-        //TODO make an AppBarColors class w/ the right colors and correct icon
-        TopAppBar(
-            title = {
-                Text(
-                    text = "Route Details",
-                    fontFamily = sfProDisplayFamily,
-                    fontStyle = FontStyle.Normal
+    val scaffoldState = rememberBottomSheetScaffoldState(sheetState)
+
+    BottomSheetScaffold(
+        scaffoldState = scaffoldState,
+        sheetContent = {
+            // Bottom sheet content
+            DetailsBottomSheet()
+        },
+        content = {
+            // Screen content
+            Column(modifier = Modifier.fillMaxSize()) {
+                //TODO make an AppBarColors class w/ the right colors and correct icon
+                TopAppBar(
+                    title = {
+                        Text(
+                            text = "Route Details",
+                            fontFamily = sfProDisplayFamily,
+                            fontStyle = FontStyle.Normal
+                        )
+                    },
+                    navigationIcon = {
+                        IconButton(onClick = { navController.popBackStack() }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowLeft,
+                                contentDescription = ""
+                            )
+                        }
+                    }
+
                 )
-            },
-            navigationIcon = {
-                IconButton(onClick = { navController.popBackStack() }) {
-                    Icon(
-                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowLeft,
-                        contentDescription = ""
-                    )
-                }
+
+                Divider(thickness = 1.dp, color = DividerGray)
+
+                DrawableMap(mapState, cameraPositionState, permissionState)
+
             }
-
-        )
-
-        Divider(thickness = 1.dp, color = DividerGray)
-
-        DrawableMap(mapState, cameraPositionState, permissionState)
-
-    }
+        }
+    )
 }
 
 @OptIn(ExperimentalPermissionsApi::class)
@@ -101,5 +135,14 @@ private fun DrawableMap(
                 )
             }
         }
+    }
+}
+
+enum class SheetValue { Collapsed, PartiallyExpanded, Expanded }
+
+@Composable
+fun DetailsBottomSheet(){
+    Column(modifier = Modifier.height(300.dp)) {
+        Text("HERE")
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/DetailsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/DetailsScreen.kt
@@ -58,7 +58,7 @@ import io.morfly.compose.bottomsheet.material3.rememberBottomSheetScaffoldState
 import io.morfly.compose.bottomsheet.material3.rememberBottomSheetState
 
 
-enum class SheetValue { Collapsed, PartiallyExpanded, Expanded }
+private enum class SheetValue { Collapsed, PartiallyExpanded, Expanded }
 
 /**
  * Screen for showing a particular route
@@ -89,7 +89,7 @@ fun DetailsScreen(navController: NavHostController, routeViewModel: RouteViewMod
             // Bottom sheet offset is 50%, i.e. it takes 50% of the screen
             SheetValue.PartiallyExpanded at offset(percent = 50)
             // Wrap full height
-            SheetValue.Expanded at contentHeight
+            SheetValue.Expanded at offset(percent = 10)
         }
     )
 
@@ -103,32 +103,7 @@ fun DetailsScreen(navController: NavHostController, routeViewModel: RouteViewMod
         },
         content = {
             // Screen content
-            Column(modifier = Modifier.fillMaxSize()) {
-                //TODO make an AppBarColors class w/ the right colors and correct icon
-                TopAppBar(
-                    title = {
-                        Text(
-                            text = "Route Details",
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal
-                        )
-                    },
-                    navigationIcon = {
-                        IconButton(onClick = { navController.popBackStack() }) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowLeft,
-                                contentDescription = ""
-                            )
-                        }
-                    }
-
-                )
-
-                HorizontalDivider(thickness = 1.dp, color = DividerGray)
-
-                DrawableMap(mapState, cameraPositionState, permissionState)
-
-            }
+            DetailsMainScreen(mapState, cameraPositionState, permissionState, navController)
         }
     )
 }
@@ -160,7 +135,7 @@ private fun DrawableMap(
 
 @RequiresApi(Build.VERSION_CODES.O)
 @Composable
-fun DetailsBottomSheet(route: Route?) {
+private fun DetailsBottomSheet(route: Route?) {
 
     if (route == null) {
         Text("No route selected")
@@ -173,7 +148,7 @@ fun DetailsBottomSheet(route: Route?) {
 
     Column(modifier = Modifier.height(700.dp)) {
         Row(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = Modifier.fillMaxWidth().padding(horizontal = 16.dp),
             horizontalArrangement = Arrangement.Center,
             verticalAlignment = Alignment.CenterVertically
         ) {
@@ -229,6 +204,42 @@ fun DetailsBottomSheet(route: Route?) {
                 )
             }
         }
+
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalPermissionsApi::class)
+@Composable
+private fun DetailsMainScreen(
+    mapState: MapState,
+    cameraPositionState: CameraPositionState,
+    permissionState: PermissionState,
+    navController: NavHostController
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        //TODO make an AppBarColors class w/ the right colors and correct icon
+        TopAppBar(
+            title = {
+                Text(
+                    text = "Route Details",
+                    fontFamily = sfProDisplayFamily,
+                    fontStyle = FontStyle.Normal
+                )
+            },
+            navigationIcon = {
+                IconButton(onClick = { navController.popBackStack() }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.KeyboardArrowLeft,
+                        contentDescription = ""
+                    )
+                }
+            }
+
+        )
+
+        HorizontalDivider(thickness = 1.dp, color = DividerGray)
+
+        DrawableMap(mapState, cameraPositionState, permissionState)
 
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -225,7 +226,8 @@ fun HomeScreen(
         bottomSheetState = SheetState(
             skipPartiallyExpanded = false,
             initialValue = SheetValue.Expanded,
-            skipHiddenState = true
+            skipHiddenState = true,
+            density = LocalDensity.current
         )
     )
 
@@ -233,7 +235,8 @@ fun HomeScreen(
     val addSheetState = rememberBottomSheetScaffoldState(
         bottomSheetState = SheetState(
             skipPartiallyExpanded = true,
-            initialValue = SheetValue.Hidden
+            initialValue = SheetValue.Hidden,
+            density = LocalDensity.current
         )
     )
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,8 +9,8 @@ buildscript {
 }
 
 plugins {
-    id("com.android.application") version "8.1.1" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.0" apply false
+    id("com.android.application") version "8.1.4" apply false
+    id("org.jetbrains.kotlin.android") version "2.0.0" apply false
     id("com.google.dagger.hilt.android") version "2.50" apply false
     id("org.jetbrains.kotlin.plugin.serialization") version "1.6.21"
 }


### PR DESCRIPTION
Overview:
* Updated Compose and Material version due to a bug between NavHost and BottomSheets (see: https://issuetracker.google.com/issues/295536718)
* Implemented three stage bottom sheet for route details, currently mostly empty with lo-fi design to demonstrate

![image](https://github.com/user-attachments/assets/64c0822a-a58e-4aa2-8bf1-950eccbe3418)
![image](https://github.com/user-attachments/assets/4e144615-87d7-43c6-b8fd-a905098d79d0)
![image](https://github.com/user-attachments/assets/321b0486-44b9-4d74-964b-bf0b018f6d6a)
![image](https://github.com/user-attachments/assets/aa77a09d-4316-4fde-91af-2cee10dafaf3)

