### PR TITLE
RouteCell refactor to display multiple combinations of directions

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.graphics.Color
 import com.cornellappdev.transit.ui.theme.LateRed
 import com.cornellappdev.transit.ui.theme.LiveGreen
 import com.cornellappdev.transit.util.TimeUtils
+import java.util.Locale
 
 /**
  * Enum representing whether a bus is late
@@ -31,7 +32,7 @@ enum class BusLateness {
 /**
  * Class representing a total path for a route
  */
-class Transport(
+data class Transport(
     val startTime: String,
     val arriveTime: String,
     val lateness: BusLateness,
@@ -55,7 +56,7 @@ fun Route.toTransport(): Transport {
     return Transport(
         startTime = TimeUtils.getHHMM(this.departureTime),
         arriveTime = TimeUtils.getHHMM(this.arrivalTime),
-        distance = String.format("%.1f", this.travelDistance),
+        distance = String.format(Locale.US, "%.1f", this.travelDistance),
         start = this.startName,
         walkOnly = !containsBus,
         lateness = if (containsBus) BusLateness.LATE else BusLateness.NONE,

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -31,82 +31,37 @@ enum class BusLateness {
 /**
  * Class representing a total path for a route
  */
-sealed class Transport {
-    abstract val startTime: String
-    abstract val arriveTime: String
-    abstract val lateness: BusLateness
-
-    class WalkOnly(
-        override val startTime: String,
-        override val arriveTime: String,
-        override val lateness: BusLateness = BusLateness.NONE,
-        val distance: String,
-        val dest: String
-    ) : Transport()
-
-    class WalkAndBus(
-        override val startTime: String,
-        override val arriveTime: String,
-        val distance: String,
-        val start: String,
-        val dest: String,
-        val timeToBoard: Int,
-        val endStop: String,
-        val bus: Int,
-        override val lateness: BusLateness,
-        val transferList: List<Direction>,
-    ) : Transport()
-
-    class BusOnly(
-        override val startTime: String,
-        override val arriveTime: String,
-        val distance: String,
-        val start: String,
-        val dest: String,
-        val transferStop: String,
-        val timeToBoard: Int,
-        val firstBus: Int,
-        val secondBus: Int,
-        val transferList: List<Direction>,
-        override val lateness: BusLateness
-    ) : Transport()
-}
+class Transport (
+    val startTime: String,
+    val arriveTime: String,
+    val lateness: BusLateness,
+    val distance: String,
+    val start: String,
+    val dest: String,
+    val walkOnly: Boolean,
+    val timeToBoard: Int,
+    val directionList: List<Direction>
+)
 
 /**
  * Create a Transport object from Route
  */
 @RequiresApi(Build.VERSION_CODES.O)
 fun Route.toTransport(): Transport {
-    // TODO: We need to change the Transport class to accurately reflect all possible route configs
-    val allBus = this.directions.all { dir ->
-        dir.type == DirectionType.DEPART
-    }
+
     val containsBus = this.directions.any { dir ->
         dir.type == DirectionType.DEPART
     }
 
-    if (containsBus) {
-        return Transport.BusOnly(
-            startTime = TimeUtils.getHHMM(this.departureTime),
-            arriveTime = TimeUtils.getHHMM(this.arrivalTime),
-            distance = String.format("%.1f", this.travelDistance),
-            start = this.startName,
-            dest = this.endName,
-            firstBus = this.directions[0].routeId?.toInt() ?: 0,
-            lateness = BusLateness.LATE,
-            secondBus = this.directions[1].routeId?.toInt() ?: 0,
-            timeToBoard = 0,
-            transferStop = "",
-            transferList = this.directions
-        )
+    return Transport(
+        startTime = TimeUtils.getHHMM(this.departureTime),
+        arriveTime = TimeUtils.getHHMM(this.arrivalTime),
+        distance = String.format("%.1f", this.travelDistance),
+        start = this.startName,
+        dest = this.endName,
+        walkOnly = !containsBus,
+        lateness = if (containsBus) BusLateness.LATE else BusLateness.NONE,
+        timeToBoard = 0,
+        directionList = this.directions
+    )
     }
-    else {
-        return Transport.WalkOnly(
-            startTime = TimeUtils.getHHMM(this.departureTime),
-            arriveTime = TimeUtils.getHHMM(this.arrivalTime),
-            dest = this.endName,
-            distance = String.format("%.1f", this.travelDistance)
-        )
-    }
-
-}

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -53,7 +53,8 @@ sealed class Transport {
         val timeToBoard: Int,
         val endStop: String,
         val bus: Int,
-        override val lateness: BusLateness
+        override val lateness: BusLateness,
+        val transferList: List<Direction>,
     ) : Transport()
 
     class BusOnly(
@@ -66,6 +67,7 @@ sealed class Transport {
         val timeToBoard: Int,
         val firstBus: Int,
         val secondBus: Int,
+        val transferList: List<Direction>,
         override val lateness: BusLateness
     ) : Transport()
 }
@@ -83,7 +85,7 @@ fun Route.toTransport(): Transport {
         dir.type == DirectionType.DEPART
     }
 
-    if (allBus || containsBus) {
+    if (containsBus) {
         return Transport.BusOnly(
             startTime = TimeUtils.getHHMM(this.departureTime),
             arriveTime = TimeUtils.getHHMM(this.arrivalTime),
@@ -94,10 +96,11 @@ fun Route.toTransport(): Transport {
             lateness = BusLateness.LATE,
             secondBus = this.directions[1].routeId?.toInt() ?: 0,
             timeToBoard = 0,
-            transferStop = ""
-
+            transferStop = "",
+            transferList = this.directions
         )
-    } else {
+    }
+    else {
         return Transport.WalkOnly(
             startTime = TimeUtils.getHHMM(this.departureTime),
             arriveTime = TimeUtils.getHHMM(this.arrivalTime),

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -31,13 +31,12 @@ enum class BusLateness {
 /**
  * Class representing a total path for a route
  */
-class Transport (
+class Transport(
     val startTime: String,
     val arriveTime: String,
     val lateness: BusLateness,
     val distance: String,
     val start: String,
-    val dest: String,
     val walkOnly: Boolean,
     val timeToBoard: Int,
     val directionList: List<Direction>
@@ -58,10 +57,9 @@ fun Route.toTransport(): Transport {
         arriveTime = TimeUtils.getHHMM(this.arrivalTime),
         distance = String.format("%.1f", this.travelDistance),
         start = this.startName,
-        dest = this.endName,
         walkOnly = !containsBus,
         lateness = if (containsBus) BusLateness.LATE else BusLateness.NONE,
         timeToBoard = 0,
         directionList = this.directions
     )
-    }
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -42,7 +42,11 @@ import com.cornellappdev.transit.ui.theme.sfProDisplayFamily
 import com.cornellappdev.transit.ui.theme.sfProTextFamily
 import com.google.android.gms.maps.model.LatLng
 
-//Invariant: if transport is WalkOnly, lateness must be None <- maybe can enforce this somehow idk
+/**
+ * Composable function to display a route cell with transport details.
+ *
+ * @param transport The transport data to display in the route cell.
+ */
 @Composable
 fun RouteCell(transport: Transport) {
     val headerText =
@@ -158,6 +162,15 @@ fun RouteCell(transport: Transport) {
     }
 }
 
+/**
+ * Composable function to display a single route within a route cell.
+ *
+ * @param isBus Indicates if the route is a bus route.
+ * @param walkOnly Indicates if the route is walk-only.
+ * @param stopName The name of the stop.
+ * @param distance The distance to the stop.
+ * @param busLine The bus line number.
+ */
 @Composable
 fun SingleRoute(
     isBus: Boolean,
@@ -223,10 +236,7 @@ fun SingleRoute(
 
                 }
             }
-
-
         }
-
         Icon(
             imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
             tint = if (isBus or !walkOnly) Color.Unspecified else IconGray,
@@ -238,63 +248,16 @@ fun SingleRoute(
                 end.linkTo(startLoc.start)
             })
 
-        if (isBus) {
-            Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                tint = TransitBlue,
-                contentDescription = "",
-                modifier = Modifier
-                    .offset(y=2.dp)
-                    .constrainAs(line) {
-                    top.linkTo(startIcon.top)
-                    bottom.linkTo(parent.bottom)
-                    end.linkTo(startIcon.end)
-                    start.linkTo(startIcon.start)
-
-                })
-        } else {
-            if (walkOnly) {
-                Icon(
-                    imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                    tint = IconGray,
-                    contentDescription = "",
-                    modifier = Modifier
-                        .offset(y=2.dp)
-                        .constrainAs(line) {
-                        top.linkTo(startIcon.top)
-                        bottom.linkTo(parent.bottom)
-                        end.linkTo(startIcon.end)
-                        start.linkTo(startIcon.start)
-
-                    })
-            } else {
-                Column(verticalArrangement = Arrangement.Bottom,
-
-                    modifier = Modifier
-                        .constrainAs(line) {
-                            top.linkTo(startIcon.top)
-                            bottom.linkTo(parent.bottom)
-                            end.linkTo(startIcon.end)
-                            start.linkTo(startIcon.start)
-                        }
-                        .height(44.dp)) {
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
-                        tint = Color.Unspecified,
-                        contentDescription = "",
-                        modifier = Modifier.padding(bottom = 8.dp)
-                    )
-
-                    Icon(
-                        imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
-                        tint = Color.Unspecified,
-                        contentDescription = "",
-                        modifier = Modifier.padding(bottom = 6.dp)
-                    )
-                }
+        DrawLine(
+            isBus = isBus,
+            walkOnly = walkOnly,
+            Modifier.constrainAs(line) {
+                top.linkTo(startIcon.top)
+                bottom.linkTo(parent.bottom)
+                end.linkTo(startIcon.end)
+                start.linkTo(startIcon.start)
             }
-
-        }
+        )
 
         Text(
             stopName,
@@ -322,6 +285,43 @@ fun SingleRoute(
                 })
         }
 
+    }
+}
+
+/**
+ * Composable function to draw a line indicating the route type.
+ *
+ * @param isBus Indicates if the route is a bus route.
+ * @param walkOnly Indicates if the route is walk-only.
+ * @param modifier The modifier to be applied to the line.
+ */
+@Composable
+fun DrawLine(isBus: Boolean, walkOnly: Boolean, modifier: Modifier = Modifier) {
+    if (isBus || walkOnly) {
+        Icon(
+            imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
+            tint = if (isBus) TransitBlue else IconGray,
+            contentDescription = "",
+            modifier = modifier.offset(y = 2.dp)
+        )
+    } else {
+        Column(
+            verticalArrangement = Arrangement.Bottom,
+            modifier = modifier.height(44.dp)
+        ) {
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
+                tint = Color.Unspecified,
+                contentDescription = "",
+                modifier = Modifier.padding(bottom = 8.dp)
+            )
+            Icon(
+                imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
+                tint = Color.Unspecified,
+                contentDescription = "",
+                modifier = Modifier.padding(bottom = 6.dp)
+            )
+        }
     }
 }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -243,7 +243,9 @@ fun SingleRoute(
                 imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
                 tint = TransitBlue,
                 contentDescription = "",
-                modifier = Modifier.constrainAs(line) {
+                modifier = Modifier
+                    .offset(y=2.dp)
+                    .constrainAs(line) {
                     top.linkTo(startIcon.top)
                     bottom.linkTo(parent.bottom)
                     end.linkTo(startIcon.end)
@@ -256,7 +258,9 @@ fun SingleRoute(
                     imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
                     tint = IconGray,
                     contentDescription = "",
-                    modifier = Modifier.constrainAs(line) {
+                    modifier = Modifier
+                        .offset(y=2.dp)
+                        .constrainAs(line) {
                         top.linkTo(startIcon.top)
                         bottom.linkTo(parent.bottom)
                         end.linkTo(startIcon.end)

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -149,7 +149,10 @@ fun RouteCell(transport: Transport) {
                 contentDescription = "",
                 modifier = Modifier
                     .padding(start = 70.5.dp)
-                    .offset(y = if (transport.walkOnly) (-5).dp else 0.dp)
+                    .offset(
+                        y = if (transport.directionList.last().type == DirectionType.WALK && !transport.walkOnly)
+                            0.dp else (-5).dp
+                    )
             )
         }
     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -127,7 +127,7 @@ fun RouteCell(transport: Transport) {
  * @param transport The transport data to display in the route cell.
  */
 @Composable
-fun RouteCellHeader(transport: Transport) {
+private fun RouteCellHeader(transport: Transport) {
     val headerText =
         if (transport.walkOnly)
             "Directions" else
@@ -333,7 +333,7 @@ fun DrawLine(isBus: Boolean, walkOnly: Boolean, modifier: Modifier = Modifier) {
 
 @Preview
 @Composable
-fun PreviewSingleRouteWithDistance() {
+private fun PreviewSingleRouteWithDistance() {
     Box(modifier = Modifier.background(Color.White)) {
         SingleRoute(
             isBus = true,
@@ -348,7 +348,7 @@ fun PreviewSingleRouteWithDistance() {
 
 @Preview
 @Composable
-fun PreviewSingleRouteWithoutDistance() {
+private fun PreviewSingleRouteWithoutDistance() {
     Box(modifier = Modifier.background(Color.White)) {
         SingleRoute(
             isBus = true,
@@ -363,7 +363,7 @@ fun PreviewSingleRouteWithoutDistance() {
 
 @Preview
 @Composable
-fun PreviewSingleRouteIsWalk() {
+private fun PreviewSingleRouteIsWalk() {
     Box(modifier = Modifier.background(Color.White)) {
         SingleRoute(
             isBus = false,
@@ -378,7 +378,7 @@ fun PreviewSingleRouteIsWalk() {
 
 @Preview
 @Composable
-fun PreviewSingleRouteWalkOnlyWithDistance() {
+private fun PreviewSingleRouteWalkOnlyWithDistance() {
     Box(modifier = Modifier.background(Color.White)) {
         SingleRoute(
             isBus = false,
@@ -393,7 +393,7 @@ fun PreviewSingleRouteWalkOnlyWithDistance() {
 
 @Preview
 @Composable
-fun PreviewRouteCellBusAndWalk() {
+private fun PreviewRouteCellBusAndWalk() {
     RouteCell(
         Transport(
             startTime = "12:42AM",
@@ -441,7 +441,7 @@ fun PreviewRouteCellBusAndWalk() {
 
 @Preview
 @Composable
-fun PreviewRouteCellMultBusesAndWalk() {
+private fun PreviewRouteCellMultBusesAndWalk() {
     RouteCell(
         Transport(
             startTime = "12:42AM",
@@ -504,7 +504,7 @@ fun PreviewRouteCellMultBusesAndWalk() {
 
 @Preview
 @Composable
-fun PreviewRouteCellWalkOnly() {
+private fun PreviewRouteCellWalkOnly() {
     RouteCell(
         Transport(
             startTime = "12:42AM",

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -29,12 +28,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.constraintlayout.compose.ConstrainedLayoutReference
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.models.BusLateness
 import com.cornellappdev.transit.models.Direction
-import com.cornellappdev.transit.models.DirectionStop
 import com.cornellappdev.transit.models.DirectionType
 import com.cornellappdev.transit.models.Transport
 import com.cornellappdev.transit.ui.theme.IconGray
@@ -121,17 +118,28 @@ fun RouteCell(transport: Transport) {
                     )
                 }
             }
-            Row() {
 
-            }
-            for (direction in transport.directionList) {
-                SingleRoute(
-                    isBus = direction.type == DirectionType.DEPART,
-                    walkOnly = transport.walkOnly,
-                    stopName = direction.endLocation.toString(),
-                    distance = direction.distance,
-                    busLine = direction.routeId
-                )
+            ConstraintLayout {
+                val directionRefs = transport.directionList.map { createRef() }
+
+                for ((index, direction) in transport.directionList.withIndex()) {
+                    Box(
+                        modifier = Modifier.constrainAs(directionRefs[index]) {
+                            top.linkTo(if (index == 0) parent.top else directionRefs[index - 1].bottom)
+                            start.linkTo(parent.start)
+                            bottom.linkTo(if (index == transport.directionList.size - 1) parent.bottom else directionRefs[index + 1].top)
+                        }) {
+                        SingleRoute(
+                            isBus = direction.type == DirectionType.DEPART,
+                            walkOnly = transport.walkOnly,
+                            stopName = direction.name,
+                            distance = if (index == transport.directionList.size - 1) transport.distance else null,
+                            busLine = direction.routeId
+
+                        )
+                    }
+
+                }
             }
             Icon(
                 imageVector = if (transport.directionList.last().type == DirectionType.DEPART)
@@ -140,502 +148,9 @@ fun RouteCell(transport: Transport) {
                 tint = Color.Unspecified,
                 contentDescription = "",
                 modifier = Modifier
-                    .padding(start = 70.dp)
-                    .offset(y = if (transport.walkOnly) (-4).dp else 0.dp)
+                    .padding(start = 70.5.dp)
+                    .offset(y = if (transport.walkOnly) (-5).dp else 0.dp)
             )
-            /*when (transport) {
-                is Transport.WalkOnly -> {
-                    ConstraintLayout {
-                        val (route, dest, toIcon) = createRefs()
-
-                        Box(modifier = Modifier.constrainAs(route){
-                            top.linkTo(parent.top, margin = 8.dp)
-                            start.linkTo(parent.start)
-                        }){
-                            SingleRoute(
-                                isBus = false,
-                                walkOnly = true,
-                                stopName = "Current Location",
-                                distance = transport.distance,
-                                busLine = null
-                            )
-                        }
-
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = R.drawable.destination_stop),
-                            contentDescription = "",
-                            tint = Color.Unspecified,
-                            modifier = Modifier
-                                .size(16.dp)
-                                .constrainAs(toIcon) {
-                                    top.linkTo(route.bottom)
-                                    start.linkTo(parent.start, margin = 70.dp)
-                                }
-                        )
-
-
-                        Text(
-                            transport.dest,
-                            fontFamily = sfProDisplayFamily,
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.Normal,
-                            modifier = Modifier.constrainAs(dest) {
-                                start.linkTo(toIcon.end, margin = 14.dp)
-                                top.linkTo(toIcon.top)
-                                bottom.linkTo(toIcon.bottom)
-                            })
-
-
-                    }
-                }
-
-                is Transport.WalkAndBus -> {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Row(
-                        horizontalArrangement = Arrangement.Start,
-                        verticalAlignment = Alignment.CenterVertically,
-                        modifier = Modifier.padding(top = 0.dp)
-                    ) {
-                        Text(
-                            text = transport.lateness.text(),
-                            fontFamily = sfProDisplayFamily,
-                            color = transport.lateness.color(),
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            lineHeight = 16.sp,
-                            style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false))
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = R.drawable.live_glyph__late_),
-                            contentDescription = "",
-                            tint = transport.lateness.color()
-                        )
-                    }
-
-                    ConstraintLayout {
-                        val (endStop, startLoc, destLoc, busBox, walkIcon, dist, startIcon, endIcon, destIcon, line, el1, el2) = createRefs()
-
-                        Row(modifier = Modifier
-                            .background(
-                                color = TransitBlue,
-                                shape = RoundedCornerShape(4.dp)
-                            )
-
-
-                            .constrainAs(busBox) {
-                                top.linkTo(startLoc.bottom)
-                                bottom.linkTo(endStop.top)
-                            }) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                modifier = Modifier.padding(
-                                    horizontal = 8.dp,
-                                    vertical = 0.dp
-                                )
-                            ) {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.bus),
-                                    contentDescription = "",
-                                    tint = Color.Unspecified
-                                )
-                                Text(
-                                    "${transport.bus}",
-                                    fontFamily = sfProDisplayFamily,
-                                    fontSize = 10.sp,
-                                    fontStyle = FontStyle.Normal,
-                                    color = Color.White,
-                                )
-                            }
-                        }
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.walk),
-                            contentDescription = "",
-                            tint = Color.Unspecified,
-                            modifier = Modifier.constrainAs(walkIcon) {
-                                start.linkTo(busBox.start)
-                                end.linkTo(busBox.end)
-                                top.linkTo(endStop.bottom)
-                                bottom.linkTo(destLoc.top)
-                            })
-
-                        Text(
-                            transport.start,
-                            color = PrimaryText,
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal,
-                            fontSize = 14.sp,
-                            modifier = Modifier.constrainAs(startLoc) {
-                                top.linkTo(parent.top)
-                                start.linkTo(startIcon.end, margin = 16.dp)
-                            })
-
-                        Text(
-                            "${transport.distance} mi away",
-                            color = MetadataGray,
-                            fontFamily = sfProTextFamily,
-                            fontSize = 10.sp,
-                            modifier = Modifier.constrainAs(dist) {
-                                start.linkTo(startLoc.start)
-                                top.linkTo(startLoc.bottom, margin = (-6).dp)
-                            })
-                        Text(
-                            transport.endStop,
-                            color = PrimaryText,
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal,
-                            fontSize = 14.sp,
-                            modifier = Modifier.constrainAs(endStop) {
-                                start.linkTo(startLoc.start)
-                                top.linkTo(dist.bottom, margin = 8.dp)
-                            })
-                        Text(
-                            transport.dest,
-                            color = PrimaryText,
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal,
-                            fontSize = 14.sp,
-                            modifier = Modifier.constrainAs(destLoc) {
-                                top.linkTo(endStop.bottom, margin = 8.dp)
-                                start.linkTo(startLoc.start)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(startIcon) {
-                                end.linkTo(startLoc.start)
-                                top.linkTo(startLoc.top)
-                                bottom.linkTo(startLoc.bottom)
-                                start.linkTo(busBox.end, margin = 16.dp)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                            tint = TransitBlue,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(line) {
-                                top.linkTo(startIcon.top)
-                                bottom.linkTo(endIcon.bottom)
-                                end.linkTo(startIcon.end)
-                                start.linkTo(startIcon.start)
-
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(endIcon) {
-                                end.linkTo(startIcon.end)
-                                top.linkTo(endStop.top)
-                                bottom.linkTo(endStop.bottom)
-                                start.linkTo(startIcon.start)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.destination_stop),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(destIcon) {
-                                top.linkTo(destLoc.top)
-                                bottom.linkTo(destLoc.bottom)
-                                end.linkTo(startIcon.end)
-                                start.linkTo(startIcon.start)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(el1) {
-                                top.linkTo(endIcon.bottom)
-                                bottom.linkTo(walkIcon.bottom, margin = 7.dp)
-                                end.linkTo(destIcon.end)
-                                start.linkTo(destIcon.start)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(el2) {
-                                top.linkTo(el1.bottom)
-                                bottom.linkTo(destIcon.top)
-                                end.linkTo(destIcon.end)
-                                start.linkTo(destIcon.start)
-                            })
-
-                    }
-
-
-                }
-
-                is Transport.HasBus -> {
-                    Spacer(modifier = Modifier.height(4.dp))
-                    Row(
-                        horizontalArrangement = Arrangement.Start,
-                        verticalAlignment = Alignment.Top
-                    ) {
-                        Text(
-                            text = transport.lateness.text(),
-                            fontFamily = sfProDisplayFamily,
-                            color = transport.lateness.color(),
-                            fontSize = 14.sp,
-                            fontWeight = FontWeight.SemiBold,
-                            style = TextStyle(platformStyle = PlatformTextStyle(includeFontPadding = false))
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                        Icon(
-                            imageVector = ImageVector.vectorResource(id = R.drawable.live_glyph__late_),
-                            contentDescription = "",
-                            tint = transport.lateness.color()
-                        )
-                    }
-
-                    ConstraintLayout {
-                        val (endStop, startLoc, destLoc, busBox, line2, lineIcon, dist, startIcon, destIcon, secondBusBox) = createRefs()
-                        lateinit var transferRefs:  MutableMap<Int, ConstrainedLayoutReference>
-                        lateinit var routeLineRefs:  MutableMap<Int, ConstrainedLayoutReference>
-                        lateinit var boardingStopRefs:  MutableMap<Int, ConstrainedLayoutReference>
-                        Row(modifier = Modifier
-                            .background(
-                                color = TransitBlue,
-                                shape = RoundedCornerShape(4.dp)
-                            )
-                            .constrainAs(busBox) {
-                                top.linkTo(startLoc.bottom)
-                                bottom.linkTo(endStop.top)
-                            }) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                modifier = Modifier.padding(
-                                    horizontal = 8.dp,
-                                    vertical = 0.dp
-                                )
-                            ) {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.bus),
-                                    contentDescription = "",
-                                    tint = Color.Unspecified
-                                )
-                                Text(
-                                    "${transport.firstBus}",
-                                    fontFamily = sfProDisplayFamily,
-                                    fontSize = 10.sp,
-                                    fontStyle = FontStyle.Normal,
-                                    color = Color.White,
-                                )
-                            }
-                        }
-
-                        Row(modifier = Modifier
-                            .background(
-                                color = TransitBlue,
-                                shape = RoundedCornerShape(4.dp)
-                            )
-
-
-                            .constrainAs(secondBusBox) {
-                                start.linkTo(busBox.start)
-                                end.linkTo(busBox.end)
-                                top.linkTo(endStop.bottom)
-                                bottom.linkTo(destLoc.top)
-                            }) {
-                            Row(
-                                verticalAlignment = Alignment.CenterVertically,
-                                horizontalArrangement = Arrangement.spacedBy(4.dp),
-                                modifier = Modifier.padding(
-                                    horizontal = 8.dp,
-                                    vertical = 0.dp
-                                )
-                            ) {
-                                Icon(
-                                    imageVector = ImageVector.vectorResource(R.drawable.bus),
-                                    contentDescription = "",
-                                    tint = Color.Unspecified
-                                )
-                                Text(
-                                    "${transport.secondBus}",
-                                    fontFamily = sfProDisplayFamily,
-                                    fontSize = 10.sp,
-                                    fontStyle = FontStyle.Normal,
-                                    color = Color.White,
-                                )
-                            }
-                        }
-
-                        Text(
-                            transport.start,
-                            color = PrimaryText,
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal,
-                            fontSize = 14.sp,
-                            modifier = Modifier.constrainAs(startLoc) {
-                                top.linkTo(parent.top)
-                                start.linkTo(startIcon.end, margin = 16.dp)
-                            })
-
-                        Text(
-                            "${transport.distance} mi away",
-                            color = MetadataGray,
-                            fontFamily = sfProTextFamily,
-                            fontSize = 10.sp,
-                            modifier = Modifier.constrainAs(dist) {
-                                start.linkTo(startLoc.start)
-                                top.linkTo(startLoc.bottom, margin = (-6).dp)
-                            })
-
-                        ConstraintLayout(modifier = Modifier.constrainAs(endStop) {
-                            start.linkTo(startLoc.start)
-                            top.linkTo(dist.bottom, margin = 0.dp)
-                        }){
-                            transferRefs = mutableMapOf()
-
-                            transport.directionList.forEachIndexed { index, _ ->
-                                transferRefs[index] = createRef()
-                            }
-                            transport.directionList.forEachIndexed { index, direction ->
-                                Text(
-                                    direction.endLocation.toString(),
-                                    color = PrimaryText,
-                                    fontFamily = sfProDisplayFamily,
-                                    fontStyle = FontStyle.Normal,
-                                    fontSize = 14.sp,
-                                    modifier = Modifier.constrainAs(transferRefs[index]!!) {
-                                        top.linkTo(
-                                            if (index == 0) parent.top else transferRefs[index - 1]!!.bottom,
-                                            margin = 8.dp
-                                        )
-                                        start.linkTo(parent.start)
-                                        end.linkTo(parent.end)
-                                    }
-                                )
-                            }
-
-                        }
-
-                        Text(
-                            transport.dest,
-                            color = PrimaryText,
-                            fontFamily = sfProDisplayFamily,
-                            fontStyle = FontStyle.Normal,
-                            fontSize = 14.sp,
-                            modifier = Modifier.constrainAs(destLoc) {
-                                top.linkTo(endStop.bottom, margin = 8.dp)
-                                start.linkTo(startLoc.start)
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(startIcon) {
-                                end.linkTo(startLoc.start)
-                                top.linkTo(startLoc.top)
-                                bottom.linkTo(startLoc.bottom)
-                                start.linkTo(busBox.end, margin = 16.dp)
-                            })
-
-                        ConstraintLayout(modifier = Modifier.constrainAs(lineIcon) {
-                            top.linkTo(startIcon.top, margin = 8.dp)
-                            bottom.linkTo(line2.top)
-                            end.linkTo(startIcon.end)
-                            start.linkTo(startIcon.start)
-                        }) {
-                            routeLineRefs = mutableMapOf()
-                            boardingStopRefs = mutableMapOf()
-
-                            transport.directionList.forEachIndexed { index, _ ->
-                                routeLineRefs[index] = createRef()
-                                boardingStopRefs[index] = createRef()
-                            }
-
-                            transport.directionList.forEachIndexed { index, _ ->
-
-                                val routeLineRef = routeLineRefs[index]!!
-                                val boardingStopRef = boardingStopRefs[index]!!
-
-                                Icon(
-                                imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                                tint = TransitBlue,
-                                contentDescription = "",
-                                    modifier = Modifier.constrainAs(routeLineRef) {
-                                        top.linkTo(
-                                            if (index == 0) startIcon.bottom else boardingStopRefs[index-1]!!.top, margin = 6.dp
-                                        )
-                                        start.linkTo(parent.start)
-                                        end.linkTo(parent.end)
-                                    })
-
-                                Icon(
-                                imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
-                                tint = Color.Unspecified,
-                                contentDescription = "",
-                                modifier = Modifier.constrainAs(boardingStopRef) {
-
-                                    bottom.linkTo(routeLineRefs[index]!!.bottom, margin =(-2).dp)
-                                    start.linkTo(parent.start)
-                                    end.linkTo(parent.end)
-                                })
-                                }
-                        }
-
-                        /*Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                            tint = TransitBlue,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(line) {
-                                top.linkTo(startIcon.top)
-                                bottom.linkTo(endIcon.bottom)
-                                end.linkTo(startIcon.end)
-                                start.linkTo(startIcon.start)
-
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.boarding_stop),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(endIcon) {
-                                end.linkTo(startIcon.end)
-                                top.linkTo(endStop.top)
-                                bottom.linkTo(endStop.bottom)
-                                start.linkTo(startIcon.start)
-                            })*/
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.bus_route_line),
-                            tint = TransitBlue,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(line2) {
-                                top.linkTo(lineIcon.bottom)
-                                bottom.linkTo(destIcon.bottom)
-                                end.linkTo(lineIcon.end)
-                                start.linkTo(lineIcon.start)
-
-                            })
-
-                        Icon(
-                            imageVector = ImageVector.vectorResource(R.drawable.bus_destination),
-                            tint = Color.Unspecified,
-                            contentDescription = "",
-                            modifier = Modifier.constrainAs(destIcon) {
-                                top.linkTo(destLoc.top)
-                                bottom.linkTo(destLoc.bottom)
-                                end.linkTo(startIcon.end)
-                                start.linkTo(startIcon.start)
-                            })
-
-
-                    }
-                }
-            }*/
         }
     }
 }
@@ -645,10 +160,10 @@ fun SingleRoute(
     isBus: Boolean,
     walkOnly: Boolean,
     stopName: String,
-    distance: String,
+    distance: String?,
     busLine: String?
 ) {
-    ConstraintLayout() {
+    ConstraintLayout {
         val (iconBox, startIcon, line, startLoc, dist) = createRefs()
         if (isBus) {
             Row(modifier = Modifier
@@ -666,7 +181,6 @@ fun SingleRoute(
                     horizontalArrangement = Arrangement.spacedBy(4.dp),
                     modifier = Modifier.padding(
                         horizontal = 8.dp,
-                        vertical = 0.dp
                     )
                 ) {
                     Icon(
@@ -696,13 +210,14 @@ fun SingleRoute(
                     contentDescription = "",
                     modifier = Modifier.align(Alignment.CenterHorizontally)
                 )
-                if (walkOnly) {
+                if (walkOnly && distance != null) {
                     Text(
-                        "$distance mi away",
+                        "${String.format("%.1f", distance.toFloat())} mi away",
                         color = MetadataGray,
                         fontFamily = sfProTextFamily,
                         fontSize = 10.sp,
                     )
+
                 }
             }
 
@@ -755,7 +270,7 @@ fun SingleRoute(
                             end.linkTo(startIcon.end)
                             start.linkTo(startIcon.start)
                         }
-                        .height(41.dp)) {
+                        .height(44.dp)) {
                     Icon(
                         imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
                         tint = Color.Unspecified,
@@ -767,7 +282,7 @@ fun SingleRoute(
                         imageVector = ImageVector.vectorResource(R.drawable.ellipse_small),
                         tint = Color.Unspecified,
                         contentDescription = "",
-                        modifier = Modifier.padding(bottom = 4.dp)
+                        modifier = Modifier.padding(bottom = 6.dp)
                     )
                 }
             }
@@ -784,18 +299,19 @@ fun SingleRoute(
                 top.linkTo(parent.top, margin = 2.dp)
                 start.linkTo(startIcon.end, margin = 16.dp)
                 end.linkTo(parent.end, margin = 16.dp)
-                bottom.linkTo(if (((distance == null)) or walkOnly) parent.bottom else dist.top)
+                bottom.linkTo(if (distance == null || walkOnly) parent.bottom else dist.top)
             })
 
-        if ((distance != null) and !walkOnly) {
+        if (distance != null && !walkOnly) {
             Text(
-                "$distance mi away",
+                "${String.format("%.1f", distance.toFloat())} mi away",
                 color = MetadataGray,
                 fontFamily = sfProTextFamily,
                 fontSize = 10.sp,
                 modifier = Modifier.constrainAs(dist) {
                     start.linkTo(startLoc.start)
                     top.linkTo(startLoc.bottom, margin = (-6).dp)
+                    bottom.linkTo(parent.bottom)
                 })
         }
 
@@ -871,10 +387,9 @@ fun PreviewRouteCell() {
             arriveTime = "12:49AM",
             distance = "0.2",
             start = "Gates Hall",
-            dest = "Collegetown Terrace Apartments",
             timeToBoard = 7,
             lateness = BusLateness.NORMAL,
-            directionList = listOf<Direction>(
+            directionList = listOf(
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
                     routeId = "30",
@@ -882,12 +397,13 @@ fun PreviewRouteCell() {
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
+                    name = "Gates Hall"
                 ),
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
@@ -896,12 +412,13 @@ fun PreviewRouteCell() {
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
+                    name = "Duffield Hall"
                 ),
             ),
             walkOnly = false
@@ -918,10 +435,9 @@ fun PreviewRouteCell2() {
             arriveTime = "12:49AM",
             distance = "0.2",
             start = "Gates Hall",
-            dest = "Collegetown Terrace Apartments",
             timeToBoard = 7,
             lateness = BusLateness.NORMAL,
-            directionList = listOf<Direction>(
+            directionList = listOf(
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
                     routeId = "30",
@@ -929,40 +445,43 @@ fun PreviewRouteCell2() {
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
+                    name = "Gates Hall"
                 ),
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
-                    routeId = "30",
+                    routeId = "",
                     tripIds = listOf("1"),
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
+                    name = "Phillips Hall"
                 ),
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
-                    routeId = "30",
+                    routeId = "81",
                     tripIds = listOf("1"),
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
+                    name = "Duffield Hall"
                 ),
             ),
             walkOnly = false
@@ -979,11 +498,10 @@ fun PreviewRouteCell3() {
             arriveTime = "12:49AM",
             distance = "0.2",
             lateness = BusLateness.NONE,
-            dest = "Collegetown Terrace Apartments",
             start = "Gates Hall",
             walkOnly = true,
             timeToBoard = 0,
-            directionList = listOf<Direction>(
+            directionList = listOf(
                 Direction(
                     endLocation = LatLng(40.7128, -74.0060),
                     routeId = "30",
@@ -991,12 +509,13 @@ fun PreviewRouteCell3() {
                     stayOnBusForTransfer = false,
                     delay = 0,
                     startLocation = LatLng(40.7128, -74.0060),
-                    path = listOf<LatLng>(),
-                    stops = listOf<DirectionStop>(),
+                    path = listOf(),
+                    stops = listOf(),
                     endTime = "12:49AM",
                     distance = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
+                    name = "Gates Hall"
                 )
             )
         )

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -80,6 +80,27 @@ fun HomeScreen(
     val permissionState = rememberPermissionState(android.Manifest.permission.ACCESS_FINE_LOCATION)
     var openDialog by remember { mutableStateOf(true) }
 
+    val scope = rememberCoroutineScope()
+
+    //SheetState for FavoritesBottomSheet
+    val favoritesSheetState = rememberBottomSheetScaffoldState(
+        bottomSheetState = SheetState(
+            skipPartiallyExpanded = false,
+            initialValue = SheetValue.Expanded,
+            skipHiddenState = true,
+            density = LocalDensity.current
+        )
+    )
+
+    //sheetState for AddFavorites BottomSheet
+    val addSheetState = rememberBottomSheetScaffoldState(
+        bottomSheetState = SheetState(
+            skipPartiallyExpanded = true,
+            initialValue = SheetValue.Hidden,
+            density = LocalDensity.current
+        )
+    )
+
     if (openDialog && !permissionState.status.isGranted) {
         AlertDialog(
             onDismissRequest = {
@@ -177,7 +198,11 @@ fun HomeScreen(
                         SearchSuggestions(
                             favorites = searchBarValue.favorites,
                             recents = searchBarValue.recents,
-                            onFavoriteAdd = {},
+                            onFavoriteAdd = {
+                                scope.launch {
+                                    addSheetState.bottomSheetState.expand()
+                                }
+                            },
                             onRecentClear = {
                                 homeViewModel.clearRecents()
                             },
@@ -221,34 +246,12 @@ fun HomeScreen(
         }
     }
 
-    //SheetState for FavoritesBottomSheet
-    val favoritesSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = SheetState(
-            skipPartiallyExpanded = false,
-            initialValue = SheetValue.Expanded,
-            skipHiddenState = true,
-            density = LocalDensity.current
-        )
-    )
-
-    //sheetState for AddFavorites BottomSheet
-    val addSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = SheetState(
-            skipPartiallyExpanded = true,
-            initialValue = SheetValue.Hidden,
-            density = LocalDensity.current
-        )
-    )
-
     var editState by remember {
         mutableStateOf(false)
     }
     var editText by remember {
         mutableStateOf("Edit")
     }
-
-    val scope = rememberCoroutineScope()
-
 
     // Favorites BottomSheet
     BottomSheetScaffold(

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -493,14 +493,15 @@ private fun RouteOptionsMainMenu(
                     }
                 }
 
-                //TODO this should probably be an IconButton that swaps current/dest
                 Icon(
                     imageVector = ImageVector.vectorResource(
                         id = R.drawable.swap
                     ),
                     contentDescription = "",
-                    modifier = Modifier.size(width = 20.dp, height = 20.dp),
-                    tint = Color.Unspecified
+                    modifier = Modifier
+                        .size(width = 20.dp, height = 20.dp)
+                        .clickable { routeViewModel.swapLocations() },
+                    tint = Color.Unspecified,
                 )
 
             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -103,7 +103,6 @@ class RouteViewModel @Inject constructor(
 
     val lastRouteFlow: StateFlow<ApiResponse<RouteOptions>> = routeRepository.lastRouteFlow
 
-    //TODO: set with an init block
     /**
      * Default map location
      */

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -103,6 +103,7 @@ class RouteViewModel @Inject constructor(
 
     val lastRouteFlow: StateFlow<ApiResponse<RouteOptions>> = routeRepository.lastRouteFlow
 
+    //TODO: set with an init block
     /**
      * Default map location
      */
@@ -282,6 +283,14 @@ class RouteViewModel @Inject constructor(
      */
     fun setMapState(value: MapState) {
         mapState.value = value
+    }
+
+    fun setStartPl(value: LocationUIState){
+        startPl.value = value
+    }
+
+    fun setDestPL(value: LocationUIState){
+        destPl.value = value
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -285,5 +285,14 @@ class RouteViewModel @Inject constructor(
         mapState.value = value
     }
 
+    /**
+     * Swap start and destination locations
+     */
+    fun swapLocations() {
+        val temp = startPl.value
+        startPl.value = destPl.value
+        destPl.value = temp
+    }
+
 }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -285,13 +285,5 @@ class RouteViewModel @Inject constructor(
         mapState.value = value
     }
 
-    fun setStartPl(value: LocationUIState){
-        startPl.value = value
-    }
-
-    fun setDestPL(value: LocationUIState){
-        destPl.value = value
-    }
-
 }
 


### PR DESCRIPTION
- `RouteCell` can now display routes with any number of bus and walk directions in any order. (Closes #44 )
- Changed `Transport` class to have no sealed classes (created unnecessary complications in `RouteScreen`)
- Added functionality to the add favorites button in the `HomeScreen` search bar
- Added functionality to the button that switches the start and end locations in `RouteScreen`

https://github.com/user-attachments/assets/1c1780f8-3d02-4dce-8ac0-4ca72a98c354


https://github.com/user-attachments/assets/483aafb4-f617-4d76-8b5e-d1a431883de8

