### PR TITLE
RouteCell UI Fixes: Stop name alignment and text overflow

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -38,6 +38,7 @@ data class Transport(
     val lateness: BusLateness,
     val distance: String,
     val start: String,
+    val end: String,
     val walkOnly: Boolean,
     val timeToBoard: Int,
     val directionList: List<Direction>
@@ -58,6 +59,7 @@ fun Route.toTransport(): Transport {
         arriveTime = TimeUtils.getHHMM(this.arrivalTime),
         distance = String.format(Locale.US, "%.1f", this.travelDistance),
         start = this.startName,
+        end = this.endName,
         walkOnly = !containsBus,
         lateness = if (containsBus) BusLateness.LATE else BusLateness.NONE,
         timeToBoard = 0,

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -125,6 +125,8 @@ fun RouteCell(transport: Transport) {
                 fontFamily = robotoFamily,
                 color = PrimaryText,
                 fontSize = 14.sp,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
                 modifier = Modifier.padding(start = 13.dp)
             )
         }
@@ -283,6 +285,7 @@ fun SingleRoute(
             fontFamily = robotoFamily,
             fontStyle = FontStyle.Normal,
             fontSize = 14.sp,
+            maxLines = 1,
             overflow = TextOverflow.Ellipsis,
             modifier = Modifier.constrainAs(startLoc) {
                 top.linkTo(parent.top)

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -127,7 +127,9 @@ fun RouteCell(transport: Transport) {
                 fontSize = 14.sp,
                 maxLines = 1,
                 overflow = TextOverflow.Ellipsis,
-                modifier = Modifier.padding(start = 13.dp)
+                modifier = Modifier
+                    .width(200.dp)
+                    .padding(start = 13.dp)
             )
         }
 
@@ -280,18 +282,20 @@ fun SingleRoute(
         )
 
         Text(
-            if (stopName.length > 60) stopName.take(60) + "..." else stopName,
+            stopName,
             color = PrimaryText,
             fontFamily = robotoFamily,
             fontStyle = FontStyle.Normal,
             fontSize = 14.sp,
             maxLines = 1,
             overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.constrainAs(startLoc) {
-                top.linkTo(parent.top)
-                start.linkTo(startIcon.end, margin = 16.dp)
-                end.linkTo(parent.end, margin = 16.dp)
-            })
+            modifier = Modifier
+                .width(200.dp)
+                .constrainAs(startLoc) {
+                    top.linkTo(parent.top)
+                    start.linkTo(startIcon.end, margin = 16.dp)
+                    end.linkTo(parent.end, margin = 16.dp)
+                })
 
         if (distance != null && !walkOnly) {
             Text(

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -95,7 +96,7 @@ fun RouteCell(transport: Transport) {
                         isBus = direction.type == DirectionType.DEPART,
                         walkOnly = transport.walkOnly,
                         stopName = direction.name,
-                        distance = if (index == transport.directionList.lastIndex) transport.distance else null,
+                        distance = if (index == 0) direction.distance else null,
                         busLine = direction.routeId
 
                     )
@@ -103,19 +104,31 @@ fun RouteCell(transport: Transport) {
 
             }
         }
-        Icon(
-            imageVector = if (transport.directionList.lastOrNull()?.type == DirectionType.DEPART)
-                ImageVector.vectorResource(R.drawable.bus_destination) else
-                ImageVector.vectorResource(R.drawable.destination_stop),
-            tint = Color.Unspecified,
-            contentDescription = "",
+        Row(
             modifier = Modifier
                 .padding(start = 70.5.dp)
                 .offset(
                     y = if (transport.directionList.lastOrNull()?.type == DirectionType.WALK && !transport.walkOnly)
                         0.dp else (-5).dp
                 )
-        )
+        ) {
+            Icon(
+                imageVector = if (transport.directionList.lastOrNull()?.type == DirectionType.DEPART)
+                    ImageVector.vectorResource(R.drawable.bus_destination) else
+                    ImageVector.vectorResource(R.drawable.destination_stop),
+                tint = Color.Unspecified,
+                contentDescription = "",
+
+                )
+            Text(
+                text = transport.end,
+                fontFamily = robotoFamily,
+                color = PrimaryText,
+                fontSize = 14.sp,
+                modifier = Modifier.padding(start = 13.dp)
+            )
+        }
+
     }
 
 }
@@ -265,16 +278,16 @@ fun SingleRoute(
         )
 
         Text(
-            stopName,
+            if (stopName.length > 60) stopName.take(60) + "..." else stopName,
             color = PrimaryText,
             fontFamily = robotoFamily,
             fontStyle = FontStyle.Normal,
             fontSize = 14.sp,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.constrainAs(startLoc) {
-                top.linkTo(parent.top, margin = 2.dp)
+                top.linkTo(parent.top)
                 start.linkTo(startIcon.end, margin = 16.dp)
                 end.linkTo(parent.end, margin = 16.dp)
-                bottom.linkTo(if (distance == null || walkOnly) parent.bottom else dist.top)
             })
 
         if (distance != null && !walkOnly) {
@@ -285,8 +298,7 @@ fun SingleRoute(
                 fontSize = 10.sp,
                 modifier = Modifier.constrainAs(dist) {
                     start.linkTo(startLoc.start)
-                    top.linkTo(startLoc.bottom, margin = (-6).dp)
-                    bottom.linkTo(parent.bottom)
+                    top.linkTo(startLoc.bottom, margin = (2).dp)
                 })
         }
 
@@ -399,6 +411,7 @@ private fun PreviewRouteCellBusAndWalk() {
             arriveTime = "12:49AM",
             distance = "0.2",
             start = "Gates Hall",
+            end = "Upson Hall",
             timeToBoard = 7,
             lateness = BusLateness.NORMAL,
             directionList = listOf(
@@ -447,6 +460,7 @@ private fun PreviewRouteCellMultBusesAndWalk() {
             arriveTime = "12:49AM",
             distance = "0.2",
             start = "Gates Hall",
+            end = "Upson Hall",
             timeToBoard = 7,
             lateness = BusLateness.NORMAL,
             directionList = listOf(
@@ -508,9 +522,10 @@ private fun PreviewRouteCellWalkOnly() {
         Transport(
             startTime = "12:42AM",
             arriveTime = "12:49AM",
-            distance = "0.2",
+            distance = "0.1",
             lateness = BusLateness.NONE,
             start = "Gates Hall",
+            end = "Upson Hall",
             walkOnly = true,
             timeToBoard = 0,
             directionList = listOf(


### PR DESCRIPTION
## Overview

Aligned stop text with stop icon and fixed textoverflow with ellipses.

## Changes Made

- Modified the `Transport` data class to have a field for the end location and modified `toTransport` pass in end location.
- Display distance to for the first stop, instead of the last (according to the design)
- Changed stop name alignment so that it's aligned with the stop icon, and added destination stop to `RouteCell`, aligned with the destination icon.
- Replaced overflowing text in stop name and destintation name with `TextOverflow.Ellipsis`

## Related PRs or Issues 

 #51  - Change routecell so stop name is next to stop icon 

## Screenshots
<details>
  <summary>Preview of component</summary>

  ![image](https://github.com/user-attachments/assets/267cfcdc-2b93-44a3-93a7-25615c5df637)

</details>
