### PR TITLE
Route Reinitialization fix

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -2,7 +2,6 @@ package com.cornellappdev.transit.models
 
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.networking.NetworkApi
-import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,14 +34,6 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
     private val _lastRouteFlow: MutableStateFlow<ApiResponse<RouteOptions>> =
         MutableStateFlow(ApiResponse.Pending)
 
-    private val _startPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
-        LocationUIState.Place("Current Location", LatLng(42.44, -76.50))
-    )
-
-    private val _destPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
-        LocationUIState.Place("Current Location", LatLng(42.45, -76.51))
-    )
-
     init {
         fetchAllStops()
     }
@@ -61,16 +52,6 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
      * A StateFlow holding the last queried location
      */
     val placeFlow = _placeFlow.asStateFlow()
-
-    /**
-     * Pair of the name of the starting location and the coordinates
-     */
-    val startPlace = _startPlace.asStateFlow()
-
-    /**
-     * Pair of the name of the ending location and the coordinates
-     */
-    val destPlace = _destPlace.asStateFlow()
 
     /**
      * Makes a new call to backend for all stops.
@@ -140,20 +121,6 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
                 _lastRouteFlow.value = ApiResponse.Error
             }
         }
-    }
-
-    /**
-     * Change start location
-     */
-    fun setStartLocation(location: LocationUIState) {
-        _startPlace.value = location
-    }
-
-    /**
-     * Change end location
-     */
-    fun setEndLocation(location: LocationUIState) {
-        _destPlace.value = location
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -35,11 +35,11 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
     private val _lastRouteFlow: MutableStateFlow<ApiResponse<RouteOptions>> =
         MutableStateFlow(ApiResponse.Pending)
 
-    private val _startPl: MutableStateFlow<LocationUIState> = MutableStateFlow(
+    private val _startPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
         LocationUIState.Place("Current Location", LatLng(42.44, -76.50))
     )
 
-    private val _destPl: MutableStateFlow<LocationUIState> = MutableStateFlow(
+    private val _destPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
         LocationUIState.Place("Current Location", LatLng(42.45, -76.51))
     )
 
@@ -65,12 +65,12 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
     /**
      * Pair of the name of the starting location and the coordinates
      */
-    val startPl = _startPl.asStateFlow()
+    val startPlace = _startPlace.asStateFlow()
 
     /**
      * Pair of the name of the ending location and the coordinates
      */
-    val destPl = _destPl.asStateFlow()
+    val destPlace = _destPlace.asStateFlow()
 
     /**
      * Makes a new call to backend for all stops.
@@ -146,14 +146,14 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
      * Change start location
      */
     fun setStartLocation(location: LocationUIState) {
-        _startPl.value = location
+        _startPlace.value = location
     }
 
     /**
      * Change end location
      */
     fun setEndLocation(location: LocationUIState) {
-        _destPl.value = location
+        _destPlace.value = location
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteRepository.kt
@@ -1,8 +1,8 @@
 package com.cornellappdev.transit.models
 
-import android.util.Log
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.networking.NetworkApi
+import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -35,6 +35,14 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
     private val _lastRouteFlow: MutableStateFlow<ApiResponse<RouteOptions>> =
         MutableStateFlow(ApiResponse.Pending)
 
+    private val _startPl: MutableStateFlow<LocationUIState> = MutableStateFlow(
+        LocationUIState.Place("Current Location", LatLng(42.44, -76.50))
+    )
+
+    private val _destPl: MutableStateFlow<LocationUIState> = MutableStateFlow(
+        LocationUIState.Place("Current Location", LatLng(42.45, -76.51))
+    )
+
     init {
         fetchAllStops()
     }
@@ -54,6 +62,15 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
      */
     val placeFlow = _placeFlow.asStateFlow()
 
+    /**
+     * Pair of the name of the starting location and the coordinates
+     */
+    val startPl = _startPl.asStateFlow()
+
+    /**
+     * Pair of the name of the ending location and the coordinates
+     */
+    val destPl = _destPl.asStateFlow()
 
     /**
      * Makes a new call to backend for all stops.
@@ -123,6 +140,20 @@ class RouteRepository @Inject constructor(private val networkApi: NetworkApi) {
                 _lastRouteFlow.value = ApiResponse.Error
             }
         }
+    }
+
+    /**
+     * Change start location
+     */
+    fun setStartLocation(location: LocationUIState) {
+        _startPl.value = location
+    }
+
+    /**
+     * Change end location
+     */
+    fun setEndLocation(location: LocationUIState) {
+        _destPl.value = location
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
@@ -29,16 +29,18 @@ class SelectedRouteRepository @Inject constructor() {
     val destPlace = _destPlace.asStateFlow()
 
     /**
-     * Change start location
+     * Change the start location [_startPlace]
+     * @param location The new starting location as a LocationUIState
      */
-    fun setStartLocation(location: LocationUIState) {
+    fun setStartPlace(location: LocationUIState) {
         _startPlace.value = location
     }
 
     /**
-     * Change end location
+     * Change the destination location [_destPlace]
+     * @param location The new destination location as a LocationUIState
      */
-    fun setEndLocation(location: LocationUIState) {
+    fun setDestPlace(location: LocationUIState) {
         _destPlace.value = location
     }
 

--- a/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
@@ -1,0 +1,45 @@
+package com.cornellappdev.transit.models
+
+import com.cornellappdev.transit.ui.viewmodels.LocationUIState
+import com.google.android.gms.maps.model.LatLng
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class SelectedRouteRepository @Inject constructor() {
+
+    private val _startPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
+        LocationUIState.Place("Current Location", LatLng(42.44, -76.50))
+    )
+
+    private val _destPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
+        LocationUIState.Place("Current Location", LatLng(42.45, -76.51))
+    )
+
+    /**
+     * Pair of the name of the starting location and the coordinates
+     */
+    val startPlace = _startPlace.asStateFlow()
+
+    /**
+     * Pair of the name of the ending location and the coordinates
+     */
+    val destPlace = _destPlace.asStateFlow()
+
+    /**
+     * Change start location
+     */
+    fun setStartLocation(location: LocationUIState) {
+        _startPlace.value = location
+    }
+
+    /**
+     * Change end location
+     */
+    fun setEndLocation(location: LocationUIState) {
+        _destPlace.value = location
+    }
+
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -3,7 +3,6 @@ package com.cornellappdev.transit.ui
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -11,7 +10,6 @@ import androidx.navigation.compose.rememberNavController
 import com.cornellappdev.transit.ui.screens.DetailsScreen
 import com.cornellappdev.transit.ui.screens.HomeScreen
 import com.cornellappdev.transit.ui.screens.RouteScreen
-import com.cornellappdev.transit.ui.screens.SettingsScreen
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
 
@@ -45,10 +43,5 @@ fun NavigationController(
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
 
-        composable("settings") {
-            SettingsScreen(
-                LocalContext.current
-            )
-        }
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -3,7 +3,6 @@ package com.cornellappdev.transit.ui
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
@@ -14,10 +13,7 @@ import com.cornellappdev.transit.ui.screens.HomeScreen
 import com.cornellappdev.transit.ui.screens.RouteScreen
 import com.cornellappdev.transit.ui.screens.SettingsScreen
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
-import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
-import com.cornellappdev.transit.util.StringUtils.fromURLString
-import com.google.android.gms.maps.model.LatLng
 
 /**
  * The navigation controller for the app (parent of all screens)
@@ -37,29 +33,7 @@ fun NavigationController(
         composable("home") {
             HomeScreen(homeViewModel = homeViewModel, navController = navController)
         }
-        composable("route/{destination}/{latitude}/{longitude}") { backStackEntry ->
-            val destArg = backStackEntry.arguments?.getString("destination")
-            val latitudeArg = backStackEntry.arguments?.getString("latitude")
-            val longitudeArg = backStackEntry.arguments?.getString("longitude")
-            val currentLocation = routeViewModel.currentLocation.collectAsState().value
-            if (destArg != null && latitudeArg != null && longitudeArg != null && currentLocation != null) {
-                routeViewModel.setStartLocation(
-                    LocationUIState.CurrentLocation(
-                        LatLng(currentLocation.latitude, currentLocation.longitude)
-                    )
-                )
-                routeViewModel.setEndLocation(
-                    LocationUIState.Place(
-                        destArg.fromURLString(),
-                        LatLng(
-                            latitudeArg.toDouble(),
-                            longitudeArg.toDouble()
-                        )
-                    )
-                )
-            }
-            RouteScreen(navController = navController, routeViewModel = routeViewModel)
-        }
+
         composable("details") {
             DetailsScreen(
                 navController = navController,

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -4,6 +4,7 @@ import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -11,6 +12,7 @@ import androidx.navigation.compose.rememberNavController
 import com.cornellappdev.transit.ui.screens.DetailsScreen
 import com.cornellappdev.transit.ui.screens.HomeScreen
 import com.cornellappdev.transit.ui.screens.RouteScreen
+import com.cornellappdev.transit.ui.screens.SettingsScreen
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
@@ -69,5 +71,10 @@ fun NavigationController(
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
 
+        composable("settings") {
+            SettingsScreen(
+                LocalContext.current
+            )
+        }
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -43,12 +43,12 @@ fun NavigationController(
             val longitudeArg = backStackEntry.arguments?.getString("longitude")
             val currentLocation = routeViewModel.currentLocation.collectAsState().value
             if (destArg != null && latitudeArg != null && longitudeArg != null && currentLocation != null) {
-                routeViewModel.changeStartLocation(
+                routeViewModel.setStartLocation(
                     LocationUIState.CurrentLocation(
                         LatLng(currentLocation.latitude, currentLocation.longitude)
                     )
                 )
-                routeViewModel.changeEndLocation(
+                routeViewModel.setEndLocation(
                     LocationUIState.Place(
                         destArg.fromURLString(),
                         LatLng(

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -24,7 +24,8 @@ import com.cornellappdev.transit.R
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
-import com.cornellappdev.transit.util.StringUtils.toURLString
+import com.cornellappdev.transit.ui.viewmodels.LocationUIState
+import com.google.android.gms.maps.model.LatLng
 
 
 /**
@@ -41,6 +42,7 @@ fun BottomSheetContent(
     onclick: () -> Unit,
     addOnClick: () -> Unit,
     removeOnClick: () -> Unit,
+    changeEndLocation: (LocationUIState) -> Unit,
     favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     navController: NavController
 ) {
@@ -85,7 +87,18 @@ fun BottomSheetContent(
                     label = it.name,
                     sublabel = "",
                     editing = editState,
-                    { navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}") },
+                    {
+                        changeEndLocation(
+                            LocationUIState.Place(
+                                it.name,
+                                LatLng(
+                                    it.latitude,
+                                    it.longitude
+                                )
+                            )
+                        )
+                        navController.navigate("route")
+                    },
                     addOnClick = {},
                     removeOnClick = { favoritesViewModel.removeFavorite(it); removeOnClick() },
                 )

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -12,7 +12,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.cornellappdev.transit.models.Place
-import com.cornellappdev.transit.util.StringUtils.toURLString
+import com.cornellappdev.transit.ui.viewmodels.LocationUIState
+import com.google.android.gms.maps.model.LatLng
 
 /**
  * Display for suggested searches (recents and favorites)
@@ -23,6 +24,7 @@ fun SearchSuggestions(
     recents: List<Place>,
     onFavoriteAdd: () -> Unit,
     onRecentClear: () -> Unit,
+    changeEndLocation: (LocationUIState) -> Unit,
     navController: NavController,
     onStopPressed: (Place) -> Unit,
 ) {
@@ -43,7 +45,16 @@ fun SearchSuggestions(
                 sublabel = it.subLabel,
                 onClick = {
                     onStopPressed(it)
-                    navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}")
+                    changeEndLocation(
+                        LocationUIState.Place(
+                            it.name,
+                            LatLng(
+                                it.latitude,
+                                it.longitude
+                            )
+                        )
+                    )
+                    navController.navigate("route")
                 }
             )
         }
@@ -60,7 +71,16 @@ fun SearchSuggestions(
                 sublabel = it.subLabel,
                 onClick = {
                     onStopPressed(it)
-                    navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}")
+                    changeEndLocation(
+                        LocationUIState.Place(
+                            it.name,
+                            LatLng(
+                                it.latitude,
+                                it.longitude
+                            )
+                        )
+                    )
+                    navController.navigate("route")
                 }
             )
         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
@@ -1,0 +1,42 @@
+package com.cornellappdev.transit.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cornellappdev.transit.ui.theme.robotoFamily
+
+@Composable
+fun SettingsOption(name: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .padding(top = 8.dp, bottom = 8.dp)
+            .fillMaxWidth()
+            .clickable {
+                onClick()
+            },
+    )
+    {
+        Text(
+            text = name,
+            fontSize = 24.sp,
+            fontFamily = robotoFamily,
+            fontStyle = FontStyle.Normal,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun SettingsOptionPreview() {
+    SettingsOption(name = "Privacy Policy", onClick = {})
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.transit.ui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -188,7 +189,12 @@ fun HomeScreen(
                     dividerColor = DividerGray,
                 ),
                 leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
-                trailingIcon = { Icon(Icons.Outlined.Info, "Info") },
+                trailingIcon = {
+                    Icon(
+                        Icons.Outlined.Info,
+                        "Info",
+                        Modifier.clickable { navController.navigate("settings") })
+                },
                 placeholder = { Text(text = stringResource(R.string.search_placeholder)) }
 
             ) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -53,12 +53,13 @@ import com.cornellappdev.transit.ui.components.MenuItem
 import com.cornellappdev.transit.ui.components.SearchSuggestions
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
+import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
-import com.cornellappdev.transit.util.StringUtils.toURLString
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
 import com.google.maps.android.compose.GoogleMap
 import com.google.maps.android.compose.MapProperties
 import com.google.maps.android.compose.MapUiSettings
@@ -213,6 +214,9 @@ fun HomeScreen(
                                 homeViewModel.clearRecents()
                             },
                             navController = navController,
+                            changeEndLocation = { place ->
+                                homeViewModel.changeEndLocation(place)
+                            },
                             onStopPressed = { place ->
                                 homeViewModel.addRecent(place)
                             },
@@ -236,7 +240,16 @@ fun HomeScreen(
                                             sublabel = it.subLabel,
                                             onClick = {
                                                 homeViewModel.addRecent(it)
-                                                navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}")
+                                                homeViewModel.changeEndLocation(
+                                                    LocationUIState.Place(
+                                                        it.name,
+                                                        LatLng(
+                                                            it.latitude,
+                                                            it.longitude
+                                                        )
+                                                    )
+                                                )
+                                                navController.navigate("route")
                                             })
 
                                     }
@@ -291,6 +304,9 @@ fun HomeScreen(
                     scope.launch {
                         favoritesSheetState.bottomSheetState.expand()
                     }
+                },
+                changeEndLocation = { place ->
+                    homeViewModel.changeEndLocation(place)
                 },
                 navController = navController
             )

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -97,8 +97,8 @@ fun RouteScreen(
     routeViewModel: RouteViewModel
 ) {
 
-    val startLocation = routeViewModel.startPl.collectAsState().value
-    val endLocation = routeViewModel.destPl.collectAsState().value
+    val startLocation = routeViewModel.startPlace.collectAsState().value
+    val endLocation = routeViewModel.destPlace.collectAsState().value
 
     val keyboardController = LocalSoftwareKeyboardController.current
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -747,14 +747,14 @@ private fun RouteOptionsSearchSheet(
                                 sublabel = it.subLabel,
                                 onClick = {
                                     if (isStart) {
-                                        routeViewModel.changeStartLocation(
+                                        routeViewModel.setStartLocation(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
                                             )
                                         )
                                     } else {
-                                        routeViewModel.changeEndLocation(
+                                        routeViewModel.setEndLocation(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
@@ -780,14 +780,14 @@ private fun RouteOptionsSearchSheet(
                                 sublabel = it.subLabel,
                                 onClick = {
                                     if (isStart) {
-                                        routeViewModel.changeStartLocation(
+                                        routeViewModel.setStartLocation(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
                                             )
                                         )
                                     } else {
-                                        routeViewModel.changeEndLocation(
+                                        routeViewModel.setEndLocation(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
@@ -823,14 +823,14 @@ private fun RouteOptionsSearchSheet(
                                         sublabel = it.subLabel,
                                         onClick = {
                                             if (isStart) {
-                                                routeViewModel.changeStartLocation(
+                                                routeViewModel.setStartLocation(
                                                     LocationUIState.Place(
                                                         it.name,
                                                         LatLng(it.latitude, it.longitude)
                                                     )
                                                 )
                                             } else {
-                                                routeViewModel.changeEndLocation(
+                                                routeViewModel.setEndLocation(
                                                     LocationUIState.Place(
                                                         it.name,
                                                         LatLng(it.latitude, it.longitude)

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -747,14 +747,14 @@ private fun RouteOptionsSearchSheet(
                                 sublabel = it.subLabel,
                                 onClick = {
                                     if (isStart) {
-                                        routeViewModel.setStartLocation(
+                                        routeViewModel.setStartPlace(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
                                             )
                                         )
                                     } else {
-                                        routeViewModel.setEndLocation(
+                                        routeViewModel.setDestPlace(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
@@ -780,14 +780,14 @@ private fun RouteOptionsSearchSheet(
                                 sublabel = it.subLabel,
                                 onClick = {
                                     if (isStart) {
-                                        routeViewModel.setStartLocation(
+                                        routeViewModel.setStartPlace(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
                                             )
                                         )
                                     } else {
-                                        routeViewModel.setEndLocation(
+                                        routeViewModel.setDestPlace(
                                             LocationUIState.Place(
                                                 it.name,
                                                 LatLng(it.latitude, it.longitude)
@@ -823,14 +823,14 @@ private fun RouteOptionsSearchSheet(
                                         sublabel = it.subLabel,
                                         onClick = {
                                             if (isStart) {
-                                                routeViewModel.setStartLocation(
+                                                routeViewModel.setStartPlace(
                                                     LocationUIState.Place(
                                                         it.name,
                                                         LatLng(it.latitude, it.longitude)
                                                     )
                                                 )
                                             } else {
-                                                routeViewModel.setEndLocation(
+                                                routeViewModel.setDestPlace(
                                                     LocationUIState.Place(
                                                         it.name,
                                                         LatLng(it.latitude, it.longitude)

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
@@ -1,0 +1,47 @@
+package com.cornellappdev.transit.ui.screens
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cornellappdev.transit.ui.components.SettingsOption
+import com.cornellappdev.transit.ui.theme.TransitBlue
+import com.cornellappdev.transit.ui.theme.robotoFamily
+
+@Composable
+fun SettingsScreen(context: Context) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
+    )
+    {
+        Text(
+            text = "Settings",
+            fontSize = 32.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = robotoFamily,
+            fontStyle = FontStyle.Normal,
+            color = TransitBlue,
+        )
+        SettingsOption(
+            name = "Privacy Policy",
+            onClick = {
+                val intent =
+                    Intent(Intent.ACTION_VIEW, Uri.parse("https://www.cornellappdev.com/privacy"))
+                context.startActivity(intent)
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -1,7 +1,6 @@
 package com.cornellappdev.transit.ui.viewmodels
 
 import android.content.Context
-import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
@@ -175,6 +174,13 @@ class HomeViewModel @Inject constructor(
      * Value of the current location. Can be null
      */
     val currentLocation = locationRepository.currentLocation
+
+    /**
+     * Change end location
+     */
+    fun changeEndLocation(location: LocationUIState) {
+        routeRepository.setEndLocation(location)
+    }
 
     /**
      * Start emitting location from [locationRepository]

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -181,7 +181,7 @@ class HomeViewModel @Inject constructor(
      * Change end location
      */
     fun changeEndLocation(location: LocationUIState) {
-        selectedRouteRepository.setEndLocation(location)
+        selectedRouteRepository.setDestPlace(location)
     }
 
     /**

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -6,6 +6,7 @@ import androidx.lifecycle.viewModelScope
 import com.cornellappdev.transit.models.LocationRepository
 import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.models.RouteRepository
+import com.cornellappdev.transit.models.SelectedRouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
 import com.google.android.gms.maps.model.LatLng
@@ -24,7 +25,8 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val routeRepository: RouteRepository,
     private val locationRepository: LocationRepository,
-    private val userPreferenceRepository: UserPreferenceRepository
+    private val userPreferenceRepository: UserPreferenceRepository,
+    private val selectedRouteRepository: SelectedRouteRepository
 ) : ViewModel() {
 
     /**
@@ -179,7 +181,7 @@ class HomeViewModel @Inject constructor(
      * Change end location
      */
     fun changeEndLocation(location: LocationUIState) {
-        routeRepository.setEndLocation(location)
+        selectedRouteRepository.setEndLocation(location)
     }
 
     /**

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -46,13 +46,13 @@ class RouteViewModel @Inject constructor(
     /**
      * Pair of the name of the starting location and the coordinates
      */
-    val startPl = routeRepository.startPl
+    val startPlace = routeRepository.startPlace
 
 
     /**
      * Pair of the name of the ending location and the coordinates
      */
-    val destPl = routeRepository.destPl
+    val destPlace = routeRepository.destPlace
 
     /**
      * State of the arriveBy selector
@@ -119,7 +119,7 @@ class RouteViewModel @Inject constructor(
                     )
             }
         }.launchIn(viewModelScope)
-        
+
         routeRepository.placeFlow.onEach {
             if (_searchBarUiState.value is SearchBarUIState.Query) {
                 _searchBarUiState.value =
@@ -130,7 +130,7 @@ class RouteViewModel @Inject constructor(
         }.launchIn(viewModelScope)
 
         currentLocation.onEach {
-            if (startPl.value is LocationUIState.CurrentLocation) {
+            if (startPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
                     routeRepository.setStartLocation(
                         LocationUIState.CurrentLocation(
@@ -139,7 +139,7 @@ class RouteViewModel @Inject constructor(
                     )
                 }
             }
-            if (destPl.value is LocationUIState.CurrentLocation) {
+            if (destPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
                     routeRepository.setEndLocation(
                         LocationUIState.CurrentLocation(
@@ -150,11 +150,11 @@ class RouteViewModel @Inject constructor(
             }
         }.launchIn(viewModelScope)
 
-        combine(startPl, destPl, arriveByFlow) { start, dest, arriveBy ->
+        combine(startPlace, destPlace, arriveByFlow) { start, dest, arriveBy ->
             Triple(start, dest, arriveBy)
         }.onEach {
-            // Every time startPl, destPl, or arriveBy changes, make a route request
-            combine(startPl, destPl, arriveByFlow) { start, dest, arriveBy ->
+            // Every time startPlace, destPlace, or arriveBy changes, make a route request
+            combine(startPlace, destPlace, arriveByFlow) { start, dest, arriveBy ->
                 Triple(start, dest, arriveBy)
             }.collect {
                 val startState = it.first
@@ -273,8 +273,8 @@ class RouteViewModel @Inject constructor(
      * Swap start and destination locations
      */
     fun swapLocations() {
-        val temp = startPl.value
-        routeRepository.setStartLocation(destPl.value)
+        val temp = startPlace.value
+        routeRepository.setStartLocation(destPlace.value)
         routeRepository.setEndLocation(temp)
     }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -13,6 +13,7 @@ import com.cornellappdev.transit.models.LocationRepository
 import com.cornellappdev.transit.models.MapState
 import com.cornellappdev.transit.models.RouteOptions
 import com.cornellappdev.transit.models.RouteRepository
+import com.cornellappdev.transit.models.SelectedRouteRepository
 import com.cornellappdev.transit.models.UserPreferenceRepository
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.util.TimeUtils
@@ -35,7 +36,8 @@ import javax.inject.Inject
 class RouteViewModel @Inject constructor(
     private val routeRepository: RouteRepository,
     private val locationRepository: LocationRepository,
-    private val userPreferenceRepository: UserPreferenceRepository
+    private val userPreferenceRepository: UserPreferenceRepository,
+    private val selectedRouteRepository: SelectedRouteRepository
 ) : ViewModel() {
 
     /**
@@ -46,13 +48,13 @@ class RouteViewModel @Inject constructor(
     /**
      * Pair of the name of the starting location and the coordinates
      */
-    val startPlace = routeRepository.startPlace
+    val startPlace = selectedRouteRepository.startPlace
 
 
     /**
      * Pair of the name of the ending location and the coordinates
      */
-    val destPlace = routeRepository.destPlace
+    val destPlace = selectedRouteRepository.destPlace
 
     /**
      * State of the arriveBy selector
@@ -132,7 +134,7 @@ class RouteViewModel @Inject constructor(
         currentLocation.onEach {
             if (startPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
-                    routeRepository.setStartLocation(
+                    selectedRouteRepository.setStartLocation(
                         LocationUIState.CurrentLocation(
                             LatLng(it.latitude, it.longitude)
                         )
@@ -141,7 +143,7 @@ class RouteViewModel @Inject constructor(
             }
             if (destPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
-                    routeRepository.setEndLocation(
+                    selectedRouteRepository.setEndLocation(
                         LocationUIState.CurrentLocation(
                             LatLng(it.latitude, it.longitude)
                         )
@@ -205,14 +207,14 @@ class RouteViewModel @Inject constructor(
      * Change start location
      */
     fun setStartLocation(location: LocationUIState) {
-        routeRepository.setStartLocation(location)
+        selectedRouteRepository.setStartLocation(location)
     }
 
     /**
      * Change end location
      */
     fun setEndLocation(location: LocationUIState) {
-        routeRepository.setEndLocation(location)
+        selectedRouteRepository.setEndLocation(location)
     }
 
     /**
@@ -274,8 +276,8 @@ class RouteViewModel @Inject constructor(
      */
     fun swapLocations() {
         val temp = startPlace.value
-        routeRepository.setStartLocation(destPlace.value)
-        routeRepository.setEndLocation(temp)
+        selectedRouteRepository.setStartLocation(destPlace.value)
+        selectedRouteRepository.setEndLocation(temp)
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -134,7 +134,7 @@ class RouteViewModel @Inject constructor(
         currentLocation.onEach {
             if (startPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
-                    selectedRouteRepository.setStartLocation(
+                    selectedRouteRepository.setStartPlace(
                         LocationUIState.CurrentLocation(
                             LatLng(it.latitude, it.longitude)
                         )
@@ -143,7 +143,7 @@ class RouteViewModel @Inject constructor(
             }
             if (destPlace.value is LocationUIState.CurrentLocation) {
                 if (it != null) {
-                    selectedRouteRepository.setEndLocation(
+                    selectedRouteRepository.setDestPlace(
                         LocationUIState.CurrentLocation(
                             LatLng(it.latitude, it.longitude)
                         )
@@ -204,17 +204,19 @@ class RouteViewModel @Inject constructor(
     }
 
     /**
-     * Change start location
+     * Change the start location by calling [SelectedRouteRepository.setStartPlace]
+     * @param location The new starting location as a LocationUIState
      */
-    fun setStartLocation(location: LocationUIState) {
-        selectedRouteRepository.setStartLocation(location)
+    fun setStartPlace(location: LocationUIState) {
+        selectedRouteRepository.setStartPlace(location)
     }
 
     /**
-     * Change end location
+     * Change the start location by calling [SelectedRouteRepository.setDestPlace]
+     * @param location The new starting location as a LocationUIState
      */
-    fun setEndLocation(location: LocationUIState) {
-        selectedRouteRepository.setEndLocation(location)
+    fun setDestPlace(location: LocationUIState) {
+        selectedRouteRepository.setDestPlace(location)
     }
 
     /**
@@ -276,8 +278,8 @@ class RouteViewModel @Inject constructor(
      */
     fun swapLocations() {
         val temp = startPlace.value
-        selectedRouteRepository.setStartLocation(destPlace.value)
-        selectedRouteRepository.setEndLocation(temp)
+        selectedRouteRepository.setStartPlace(destPlace.value)
+        selectedRouteRepository.setDestPlace(temp)
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -44,29 +44,13 @@ class RouteViewModel @Inject constructor(
     /**
      * Pair of the name of the starting location and the coordinates
      */
-    val startPl: MutableStateFlow<LocationUIState> =
-        MutableStateFlow(
-            LocationUIState.CurrentLocation(currentLocation.value?.longitude?.let {
-                currentLocation.value?.latitude?.let { it1 ->
-                    LatLng(
-                        it, it1
-                    )
-                }
-            })
-        )
+    val startPl = routeRepository.startPl
+
 
     /**
      * Pair of the name of the ending location and the coordinates
      */
-    val destPl: MutableStateFlow<LocationUIState> = MutableStateFlow(
-        LocationUIState.CurrentLocation(currentLocation.value?.longitude?.let {
-            currentLocation.value?.latitude?.let { it1 ->
-                LatLng(
-                    it, it1
-                )
-            }
-        })
-    )
+    val destPl = routeRepository.destPl
 
     /**
      * State of the arriveBy selector
@@ -151,15 +135,19 @@ class RouteViewModel @Inject constructor(
                 currentLocation.collect {
                     if (startPl.value is LocationUIState.CurrentLocation) {
                         if (it != null) {
-                            startPl.value = LocationUIState.CurrentLocation(
-                                LatLng(it.latitude, it.longitude)
+                            routeRepository.setStartLocation(
+                                LocationUIState.CurrentLocation(
+                                    LatLng(it.latitude, it.longitude)
+                                )
                             )
                         }
                     }
                     if (destPl.value is LocationUIState.CurrentLocation) {
                         if (it != null) {
-                            destPl.value = LocationUIState.CurrentLocation(
-                                LatLng(it.latitude, it.longitude)
+                            routeRepository.setEndLocation(
+                                LocationUIState.CurrentLocation(
+                                    LatLng(it.latitude, it.longitude)
+                                )
                             )
                         }
                     }
@@ -219,15 +207,15 @@ class RouteViewModel @Inject constructor(
     /**
      * Change start location
      */
-    fun changeStartLocation(location: LocationUIState) {
-        startPl.value = location
+    fun setStartLocation(location: LocationUIState) {
+        routeRepository.setStartLocation(location)
     }
 
     /**
      * Change end location
      */
-    fun changeEndLocation(location: LocationUIState) {
-        destPl.value = location
+    fun setEndLocation(location: LocationUIState) {
+        routeRepository.setEndLocation(location)
     }
 
     /**
@@ -289,8 +277,8 @@ class RouteViewModel @Inject constructor(
      */
     fun swapLocations() {
         val temp = startPl.value
-        startPl.value = destPl.value
-        destPl.value = temp
+        routeRepository.setStartLocation(destPl.value)
+        routeRepository.setEndLocation(temp)
     }
 
 }


### PR DESCRIPTION
## Overview
<!-- Summarize your changes here. -->
When navigating back from the route details screen to route options after changing the start/end location, the locations do not get reinitialized to the original locations.

## Changes Made
- Created `startPL` and `endPL` in routeRepository instead of routeViewmodel and created flows to be accessed by viewmodels
- Created functions to set start and end locations
- Changed route navigation to not pass in stop details
- Pass in functions to set locations to the UI components `BottomSheetContent` and `SearchSuggestions` from `HomeScreen`

## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Samsung A14 physical Emulator

## Related PRs or Issues (delete if not applicable)

Fixes #45

