### PR TITLE
Add settings page and privacy policy

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -1,9 +1,12 @@
 package com.cornellappdev.transit.ui
 
+import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -11,6 +14,7 @@ import androidx.navigation.compose.rememberNavController
 import com.cornellappdev.transit.ui.screens.DetailsScreen
 import com.cornellappdev.transit.ui.screens.HomeScreen
 import com.cornellappdev.transit.ui.screens.RouteScreen
+import com.cornellappdev.transit.ui.screens.SettingsScreen
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
@@ -67,6 +71,15 @@ fun NavigationController(
 
         composable("route") {
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
+        }
+
+        composable("info") { SettingsScreen(navController = navController) }
+
+        composable("privacyPolicy") {
+            val context = LocalContext.current
+            val intent =
+                Intent(Intent.ACTION_VIEW, Uri.parse("https://www.cornellappdev.com/privacy"))
+            context.startActivity(intent)
         }
 
     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -1,7 +1,5 @@
 package com.cornellappdev.transit.ui
 
-import android.content.Intent
-import android.net.Uri
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.compose.runtime.Composable
@@ -73,14 +71,10 @@ fun NavigationController(
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
 
-        composable("info") { SettingsScreen(navController = navController) }
-
-        composable("privacyPolicy") {
-            val context = LocalContext.current
-            val intent =
-                Intent(Intent.ACTION_VIEW, Uri.parse("https://www.cornellappdev.com/privacy"))
-            context.startActivity(intent)
+        composable("settings") {
+            SettingsScreen(
+                LocalContext.current
+            )
         }
-
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
@@ -37,6 +37,6 @@ fun SettingsOption(name: String, onClick: () -> Unit) {
 
 @Preview
 @Composable
-fun SettingsOptionPreview() {
+private fun SettingsOptionPreview() {
     SettingsOption(name = "Privacy Policy", onClick = {})
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SettingsOption.kt
@@ -1,0 +1,42 @@
+package com.cornellappdev.transit.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.cornellappdev.transit.ui.theme.robotoFamily
+
+@Composable
+fun SettingsOption(name: String, onClick: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .padding(top = 8.dp, bottom = 8.dp)
+            .fillMaxWidth()
+            .clickable {
+                onClick()
+            },
+    )
+    {
+        Text(
+            text = name,
+            fontSize = 24.sp,
+            fontFamily = robotoFamily,
+            fontStyle = FontStyle.Normal,
+            fontWeight = FontWeight.Bold,
+        )
+    }
+}
+
+@Preview
+@Composable
+fun SettingsOptionPreview() {
+    SettingsOption(name = "Privacy Policy", onClick = {})
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -193,7 +193,7 @@ fun HomeScreen(
                     Icon(
                         Icons.Outlined.Info,
                         "Info",
-                        Modifier.clickable { navController.navigate("info") })
+                        Modifier.clickable { navController.navigate("settings") })
                 },
                 placeholder = { Text(text = stringResource(R.string.search_placeholder)) }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.transit.ui.screens
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -188,7 +189,12 @@ fun HomeScreen(
                     dividerColor = DividerGray,
                 ),
                 leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
-                trailingIcon = { Icon(Icons.Outlined.Info, "Info") },
+                trailingIcon = {
+                    Icon(
+                        Icons.Outlined.Info,
+                        "Info",
+                        Modifier.clickable { navController.navigate("info") })
+                },
                 placeholder = { Text(text = stringResource(R.string.search_placeholder)) }
 
             ) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
@@ -1,0 +1,41 @@
+package com.cornellappdev.transit.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.navigation.NavController
+import com.cornellappdev.transit.ui.components.SettingsOption
+import com.cornellappdev.transit.ui.theme.TransitBlue
+import com.cornellappdev.transit.ui.theme.robotoFamily
+
+@Composable
+fun SettingsScreen(navController: NavController) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    )
+    {
+        Text(
+            text = "Settings",
+            fontSize = 32.sp,
+            fontWeight = FontWeight.Bold,
+            fontFamily = robotoFamily,
+            fontStyle = FontStyle.Normal,
+            color = TransitBlue,
+        )
+        SettingsOption(
+            name = "Privacy Policy",
+            onClick = {
+                navController.navigate("privacyPolicy")
+            }
+        )
+    }
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/SettingsScreen.kt
@@ -1,5 +1,9 @@
 package com.cornellappdev.transit.ui.screens
 
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -10,17 +14,17 @@ import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.navigation.NavController
 import com.cornellappdev.transit.ui.components.SettingsOption
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.robotoFamily
 
 @Composable
-fun SettingsScreen(navController: NavController) {
+fun SettingsScreen(context: Context) {
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp)
+            .padding(16.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp)
     )
     {
         Text(
@@ -34,7 +38,9 @@ fun SettingsScreen(navController: NavController) {
         SettingsOption(
             name = "Privacy Policy",
             onClick = {
-                navController.navigate("privacyPolicy")
+                val intent =
+                    Intent(Intent.ACTION_VIEW, Uri.parse("https://www.cornellappdev.com/privacy"))
+                context.startActivity(intent)
             }
         )
     }


### PR DESCRIPTION
## Overview

Created a settings page and added the privacy policy to it.

## Changes Made

- Created a settings screen
- Created a `settingsOption` composable for future use
- Added the privacy policy to the settings page as a `settingsOption`
- Creates a nav route for the settiings pag eand privacy policy
- Made the info icon in `HomeScreen` navigate to `SettingsScreen 

## Test Coverage

Pixel 3a emulator

## Next Steps 

This is a very basic settinsg page since there's no design for this. This will be updated with an actual settings page post-launch when the designs are done.

## Related PRs or Issues

Fixes #54 

## Screenshots 
<details>
  <summary>Settings Page</summary>

[privacypolicy.webm](https://github.com/user-attachments/assets/d451d5c5-1080-4e7f-a0e4-991a997d62c1)

</details>
