### PR TITLE
Add loading and error states

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -136,16 +136,49 @@ fun AddFavoritesSearchSheet(
                 trailingIcon = { Icon(Icons.Outlined.Info, "Info") },
                 placeholder = { Text(text = "Search for a stop to add") }
             ) {
-                LazyColumn(
-                    modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = if ((placeQueryResponse as? ApiResponse.Success)?.data?.isNotEmpty() == true)
-                        Arrangement.Top
-                    else Arrangement.Center,
-                    horizontalAlignment = Alignment.CenterHorizontally
-                ) {
-                    when (placeQueryResponse) {
-                        is ApiResponse.Error -> {
-                            item {
+                when (placeQueryResponse) {
+                    is ApiResponse.Error -> {
+                        Column(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
+                            Icon(
+                                imageVector = Icons.Rounded.Place,
+                                contentDescription = "",
+                                tint = Color.Gray,
+                                modifier = Modifier
+                                    .size(32.dp)
+                            )
+                            Text(
+                                text = "Location Not Found",
+                                fontFamily = robotoFamily,
+                                fontStyle = FontStyle.Normal,
+                                color = Color.Gray
+                            )
+                        }
+                    }
+
+                    ApiResponse.Pending -> {
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier
+                                    .size(32.dp),
+                                color = TransitBlue,
+                            )
+                        }
+                    }
+
+                    is ApiResponse.Success -> {
+                        if (placeQueryResponse.data.isEmpty()) {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
                                 Icon(
                                     imageVector = Icons.Rounded.Place,
                                     contentDescription = "",
@@ -154,29 +187,16 @@ fun AddFavoritesSearchSheet(
                                         .size(32.dp)
                                         .align(Alignment.CenterHorizontally)
                                 )
-                            }
-                            item {
                                 Text(
                                     text = "Location Not Found",
                                     fontFamily = robotoFamily,
                                     fontStyle = FontStyle.Normal,
                                     color = Color.Gray
                                 )
+
                             }
                         }
-
-                        is ApiResponse.Pending -> {
-
-                            item {
-                                CircularProgressIndicator(
-                                    modifier = Modifier.size(32.dp),
-                                    color = TransitBlue,
-                                )
-                            }
-                        }
-
-                        is ApiResponse.Success -> {
-
+                        LazyColumn {
                             items(placeQueryResponse.data) {
                                 MenuItem(
                                     type = it.type,
@@ -188,26 +208,6 @@ fun AddFavoritesSearchSheet(
                                             keyboardController?.hide()
                                         }
                                     })
-                            }
-                            if (placeQueryResponse.data.isEmpty()) {
-                                item {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Place,
-                                        contentDescription = "",
-                                        tint = Color.Gray,
-                                        modifier = Modifier
-                                            .size(32.dp)
-                                            .align(Alignment.CenterHorizontally)
-                                    )
-                                }
-                                item {
-                                    Text(
-                                        text = "Location Not Found",
-                                        fontFamily = robotoFamily,
-                                        fontStyle = FontStyle.Normal,
-                                        color = Color.Gray
-                                    )
-                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -8,9 +8,11 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
@@ -39,6 +41,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.theme.TextButtonGray
+import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
@@ -138,7 +141,13 @@ fun AddFavoritesSearchSheet(
                         }
 
                         is ApiResponse.Pending -> {
-
+                            
+                            item {
+                                CircularProgressIndicator(
+                                    modifier = Modifier.size(32.dp),
+                                    color = TransitBlue,
+                                )
+                            }
                         }
 
                         is ApiResponse.Success -> {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -6,18 +6,14 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -43,7 +39,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.theme.TextButtonGray
-import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
@@ -138,63 +133,16 @@ fun AddFavoritesSearchSheet(
             ) {
                 when (placeQueryResponse) {
                     is ApiResponse.Error -> {
-                        Column(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            Icon(
-                                imageVector = Icons.Rounded.Place,
-                                contentDescription = "",
-                                tint = Color.Gray,
-                                modifier = Modifier
-                                    .size(32.dp)
-                            )
-                            Text(
-                                text = "Location Not Found",
-                                fontFamily = robotoFamily,
-                                fontStyle = FontStyle.Normal,
-                                color = Color.Gray
-                            )
-                        }
+                        LocationNotFound()
                     }
 
                     ApiResponse.Pending -> {
-                        Box(
-                            modifier = Modifier.fillMaxSize(),
-                            contentAlignment = Alignment.Center
-                        ) {
-                            CircularProgressIndicator(
-                                modifier = Modifier
-                                    .size(32.dp),
-                                color = TransitBlue,
-                            )
-                        }
+                        ProgressCircle()
                     }
 
                     is ApiResponse.Success -> {
                         if (placeQueryResponse.data.isEmpty()) {
-                            Column(
-                                modifier = Modifier.fillMaxSize(),
-                                verticalArrangement = Arrangement.Center,
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Place,
-                                    contentDescription = "",
-                                    tint = Color.Gray,
-                                    modifier = Modifier
-                                        .size(32.dp)
-                                        .align(Alignment.CenterHorizontally)
-                                )
-                                Text(
-                                    text = "Location Not Found",
-                                    fontFamily = robotoFamily,
-                                    fontStyle = FontStyle.Normal,
-                                    color = Color.Gray
-                                )
-
-                            }
+                            LocationNotFound()
                         }
                         LazyColumn {
                             items(placeQueryResponse.data) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -16,6 +17,7 @@ import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -134,14 +136,37 @@ fun AddFavoritesSearchSheet(
                 trailingIcon = { Icon(Icons.Outlined.Info, "Info") },
                 placeholder = { Text(text = "Search for a stop to add") }
             ) {
-                LazyColumn {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    verticalArrangement = if ((placeQueryResponse as? ApiResponse.Success)?.data?.isNotEmpty() == true)
+                        Arrangement.Top
+                    else Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
                     when (placeQueryResponse) {
                         is ApiResponse.Error -> {
-
+                            item {
+                                Icon(
+                                    imageVector = Icons.Rounded.Place,
+                                    contentDescription = "",
+                                    tint = Color.Gray,
+                                    modifier = Modifier
+                                        .size(32.dp)
+                                        .align(Alignment.CenterHorizontally)
+                                )
+                            }
+                            item {
+                                Text(
+                                    text = "Location Not Found",
+                                    fontFamily = robotoFamily,
+                                    fontStyle = FontStyle.Normal,
+                                    color = Color.Gray
+                                )
+                            }
                         }
 
                         is ApiResponse.Pending -> {
-                            
+
                             item {
                                 CircularProgressIndicator(
                                     modifier = Modifier.size(32.dp),
@@ -163,6 +188,26 @@ fun AddFavoritesSearchSheet(
                                             keyboardController?.hide()
                                         }
                                     })
+                            }
+                            if (placeQueryResponse.data.isEmpty()) {
+                                item {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Place,
+                                        contentDescription = "",
+                                        tint = Color.Gray,
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .align(Alignment.CenterHorizontally)
+                                    )
+                                }
+                                item {
+                                    Text(
+                                        text = "Location Not Found",
+                                        fontFamily = robotoFamily,
+                                        fontStyle = FontStyle.Normal,
+                                        color = Color.Gray
+                                    )
+                                }
                             }
                         }
                     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/LocationNotFound.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/LocationNotFound.kt
@@ -1,0 +1,49 @@
+package com.cornellappdev.transit.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.rounded.Place
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.transit.ui.theme.robotoFamily
+
+@Composable
+fun LocationNotFound() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Icon(
+            imageVector = Icons.Rounded.Place,
+            contentDescription = "",
+            tint = Color.Gray,
+            modifier = Modifier
+                .size(32.dp)
+                .align(Alignment.CenterHorizontally)
+        )
+        Text(
+            text = "Location Not Found",
+            fontFamily = robotoFamily,
+            fontStyle = FontStyle.Normal,
+            color = Color.Gray
+        )
+
+    }
+}
+
+@Preview
+@Composable
+private fun LocationNotFoundPreview() {
+    LocationNotFound()
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/ProgressCircle.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/ProgressCircle.kt
@@ -1,0 +1,32 @@
+package com.cornellappdev.transit.ui.components
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.cornellappdev.transit.ui.theme.TransitBlue
+
+@Composable
+fun ProgressCircle() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator(
+            modifier = Modifier
+                .size(32.dp),
+            color = TransitBlue,
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewProgressCircle() {
+    ProgressCircle()
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -7,11 +7,13 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
@@ -51,6 +53,7 @@ import com.cornellappdev.transit.ui.components.BottomSheetContent
 import com.cornellappdev.transit.ui.components.MenuItem
 import com.cornellappdev.transit.ui.components.SearchSuggestions
 import com.cornellappdev.transit.ui.theme.DividerGray
+import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
 import com.cornellappdev.transit.util.StringUtils.toURLString
@@ -217,9 +220,20 @@ fun HomeScreen(
                         LazyColumn {
                             when (searchBarValue.searched) {
                                 is ApiResponse.Error -> {
+                                    item {
+                                        Text("error")
+                                    }
                                 }
 
                                 is ApiResponse.Pending -> {
+                                    item {
+                                        CircularProgressIndicator(
+                                            modifier = Modifier
+                                                .size(32.dp)
+                                                .align(Alignment.CenterHorizontally),
+                                            color = TransitBlue,
+                                        )
+                                    }
                                 }
 
                                 is ApiResponse.Success -> {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BottomSheetScaffold
@@ -44,6 +45,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
@@ -54,6 +56,7 @@ import com.cornellappdev.transit.ui.components.MenuItem
 import com.cornellappdev.transit.ui.components.SearchSuggestions
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.theme.TransitBlue
+import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
 import com.cornellappdev.transit.util.StringUtils.toURLString
@@ -221,7 +224,22 @@ fun HomeScreen(
                             when (searchBarValue.searched) {
                                 is ApiResponse.Error -> {
                                     item {
-                                        Text("error")
+                                        Icon(
+                                            imageVector = Icons.Rounded.Place,
+                                            contentDescription = "",
+                                            tint = Color.Gray,
+                                            modifier = Modifier
+                                                .size(32.dp)
+                                                .align(Alignment.CenterHorizontally)
+                                        )
+                                    }
+                                    item {
+                                        Text(
+                                            text = "Location Not Found",
+                                            fontFamily = robotoFamily,
+                                            fontStyle = FontStyle.Normal,
+                                            color = Color.Gray
+                                        )
                                     }
                                 }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -1,5 +1,6 @@
 package com.cornellappdev.transit.ui.screens
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -220,7 +221,13 @@ fun HomeScreen(
                     }
 
                     is SearchBarUIState.Query -> {
-                        LazyColumn {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize(),
+                            verticalArrangement = if ((searchBarValue.searched as? ApiResponse.Success)?.data?.isNotEmpty() == true)
+                                Arrangement.Top
+                            else Arrangement.Center,
+                            horizontalAlignment = Alignment.CenterHorizontally
+                        ) {
                             when (searchBarValue.searched) {
                                 is ApiResponse.Error -> {
                                     item {
@@ -267,7 +274,24 @@ fun HomeScreen(
 
                                     }
                                     if (searchBarValue.searched.data.isEmpty()) {
-                                        item { Text("No search results") }
+                                        item {
+                                            Icon(
+                                                imageVector = Icons.Rounded.Place,
+                                                contentDescription = "",
+                                                tint = Color.Gray,
+                                                modifier = Modifier
+                                                    .size(32.dp)
+                                                    .align(Alignment.CenterHorizontally)
+                                            )
+                                        }
+                                        item {
+                                            Text(
+                                                text = "Location Not Found",
+                                                fontFamily = robotoFamily,
+                                                fontStyle = FontStyle.Normal,
+                                                color = Color.Gray
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -221,76 +221,72 @@ fun HomeScreen(
                     }
 
                     is SearchBarUIState.Query -> {
-                        LazyColumn(
-                            modifier = Modifier.fillMaxSize(),
-                            verticalArrangement = if ((searchBarValue.searched as? ApiResponse.Success)?.data?.isNotEmpty() == true)
-                                Arrangement.Top
-                            else Arrangement.Center,
-                            horizontalAlignment = Alignment.CenterHorizontally
-                        ) {
-                            when (searchBarValue.searched) {
-                                is ApiResponse.Error -> {
-                                    item {
+                        when (searchBarValue.searched) {
+                            is ApiResponse.Error -> {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    Text(
+                                        text = "Location Not Found",
+                                        fontFamily = robotoFamily,
+                                        fontStyle = FontStyle.Normal,
+                                        color = Color.Gray,
+                                        modifier = Modifier.fillMaxSize()
+                                    )
+                                }
+                            }
+
+                            is ApiResponse.Pending -> {
+                                Box(
+                                    modifier = Modifier.fillMaxSize(),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .size(32.dp),
+                                        color = TransitBlue,
+                                    )
+                                }
+                            }
+
+                            is ApiResponse.Success -> {
+                                if (searchBarValue.searched.data.isEmpty()) {
+                                    Column(
+                                        modifier = Modifier.fillMaxSize(),
+                                        verticalArrangement = Arrangement.Center,
+                                        horizontalAlignment = Alignment.CenterHorizontally
+                                    ) {
                                         Icon(
                                             imageVector = Icons.Rounded.Place,
                                             contentDescription = "",
                                             tint = Color.Gray,
                                             modifier = Modifier
                                                 .size(32.dp)
-                                                .align(Alignment.CenterHorizontally)
+
                                         )
-                                    }
-                                    item {
+
                                         Text(
                                             text = "Location Not Found",
                                             fontFamily = robotoFamily,
                                             fontStyle = FontStyle.Normal,
-                                            color = Color.Gray
+                                            color = Color.Gray,
                                         )
                                     }
-                                }
 
-                                is ApiResponse.Pending -> {
-                                    item {
-                                        CircularProgressIndicator(
-                                            modifier = Modifier
-                                                .size(32.dp)
-                                                .align(Alignment.CenterHorizontally),
-                                            color = TransitBlue,
-                                        )
-                                    }
-                                }
 
-                                is ApiResponse.Success -> {
-                                    items(searchBarValue.searched.data) {
-                                        MenuItem(
-                                            type = it.type,
-                                            label = it.name,
-                                            sublabel = it.subLabel,
-                                            onClick = {
-                                                homeViewModel.addRecent(it)
-                                                navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}")
-                                            })
+                                } else {
+                                    LazyColumn {
+                                        items(searchBarValue.searched.data) {
+                                            MenuItem(
+                                                type = it.type,
+                                                label = it.name,
+                                                sublabel = it.subLabel,
+                                                onClick = {
+                                                    homeViewModel.addRecent(it)
+                                                    navController.navigate("route/${it.name.toURLString()}/${it.latitude}/${it.longitude}")
+                                                })
 
-                                    }
-                                    if (searchBarValue.searched.data.isEmpty()) {
-                                        item {
-                                            Icon(
-                                                imageVector = Icons.Rounded.Place,
-                                                contentDescription = "",
-                                                tint = Color.Gray,
-                                                modifier = Modifier
-                                                    .size(32.dp)
-                                                    .align(Alignment.CenterHorizontally)
-                                            )
-                                        }
-                                        item {
-                                            Text(
-                                                text = "Location Not Found",
-                                                fontFamily = robotoFamily,
-                                                fontStyle = FontStyle.Normal,
-                                                color = Color.Gray
-                                            )
                                         }
                                     }
                                 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -1,7 +1,6 @@
 package com.cornellappdev.transit.ui.screens
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -9,18 +8,15 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AlertDialogDefaults
 import androidx.compose.material3.BottomSheetScaffold
@@ -47,18 +43,17 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontStyle
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.components.AddFavoritesSearchSheet
 import com.cornellappdev.transit.ui.components.BottomSheetContent
+import com.cornellappdev.transit.ui.components.LocationNotFound
 import com.cornellappdev.transit.ui.components.MenuItem
+import com.cornellappdev.transit.ui.components.ProgressCircle
 import com.cornellappdev.transit.ui.components.SearchSuggestions
 import com.cornellappdev.transit.ui.theme.DividerGray
-import com.cornellappdev.transit.ui.theme.TransitBlue
-import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
 import com.cornellappdev.transit.util.StringUtils.toURLString
@@ -232,58 +227,16 @@ fun HomeScreen(
                     is SearchBarUIState.Query -> {
                         when (searchBarValue.searched) {
                             is ApiResponse.Error -> {
-                                Box(
-                                    modifier = Modifier.fillMaxSize(),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    Text(
-                                        text = "Location Not Found",
-                                        fontFamily = robotoFamily,
-                                        fontStyle = FontStyle.Normal,
-                                        color = Color.Gray,
-                                        modifier = Modifier.fillMaxSize()
-                                    )
-                                }
+                                LocationNotFound()
                             }
 
                             is ApiResponse.Pending -> {
-                                Box(
-                                    modifier = Modifier.fillMaxSize(),
-                                    contentAlignment = Alignment.Center
-                                ) {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier
-                                            .size(32.dp),
-                                        color = TransitBlue,
-                                    )
-                                }
+                                ProgressCircle()
                             }
 
                             is ApiResponse.Success -> {
                                 if (searchBarValue.searched.data.isEmpty()) {
-                                    Column(
-                                        modifier = Modifier.fillMaxSize(),
-                                        verticalArrangement = Arrangement.Center,
-                                        horizontalAlignment = Alignment.CenterHorizontally
-                                    ) {
-                                        Icon(
-                                            imageVector = Icons.Rounded.Place,
-                                            contentDescription = "",
-                                            tint = Color.Gray,
-                                            modifier = Modifier
-                                                .size(32.dp)
-
-                                        )
-
-                                        Text(
-                                            text = "Location Not Found",
-                                            fontFamily = robotoFamily,
-                                            fontStyle = FontStyle.Normal,
-                                            color = Color.Gray,
-                                        )
-                                    }
-
-
+                                    LocationNotFound()
                                 } else {
                                     LazyColumn {
                                         items(searchBarValue.searched.data) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
@@ -27,7 +26,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
 import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.material.icons.outlined.Search
-import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -60,7 +58,9 @@ import com.cornellappdev.transit.models.Transport
 import com.cornellappdev.transit.models.toTransport
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.components.DatePicker
+import com.cornellappdev.transit.ui.components.LocationNotFound
 import com.cornellappdev.transit.ui.components.MenuItem
+import com.cornellappdev.transit.ui.components.ProgressCircle
 import com.cornellappdev.transit.ui.components.RouteCell
 import com.cornellappdev.transit.ui.components.SearchTextField
 import com.cornellappdev.transit.ui.components.TernarySelector
@@ -594,16 +594,7 @@ private fun RouteList(
         }
 
         is ApiResponse.Pending -> {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize(),
-                contentAlignment = Alignment.Center
-            ) {
-                CircularProgressIndicator(
-                    modifier = Modifier.size(32.dp),
-                    color = TransitBlue,
-                )
-            }
+            ProgressCircle()
         }
 
         is ApiResponse.Success -> {
@@ -753,65 +744,16 @@ private fun RouteOptionsSearchSheet(
                 is SearchBarUIState.Query -> {
                     when (searchBarValue.searched) {
                         ApiResponse.Error -> {
-                            Column(
-                                modifier = Modifier.fillMaxSize(),
-                                verticalArrangement = Arrangement.Center,
-                                horizontalAlignment = Alignment.CenterHorizontally
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Rounded.Place,
-                                    contentDescription = "",
-                                    tint = Color.Gray,
-                                    modifier = Modifier
-                                        .size(32.dp)
-                                        .align(Alignment.CenterHorizontally)
-                                )
-                                Text(
-                                    text = "Location Not Found",
-                                    fontFamily = robotoFamily,
-                                    fontStyle = FontStyle.Normal,
-                                    color = Color.Gray
-                                )
-
-                            }
+                            LocationNotFound()
                         }
 
                         ApiResponse.Pending -> {
-                            Box(
-                                modifier = Modifier.fillMaxSize(),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                CircularProgressIndicator(
-                                    modifier = Modifier
-                                        .size(32.dp),
-                                    color = TransitBlue,
-                                )
-                            }
+                            ProgressCircle()
                         }
 
                         is ApiResponse.Success -> {
                             if (searchBarValue.searched.data.isEmpty()) {
-                                Column(
-                                    modifier = Modifier.fillMaxSize(),
-                                    verticalArrangement = Arrangement.Center,
-                                    horizontalAlignment = Alignment.CenterHorizontally
-                                ) {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Place,
-                                        contentDescription = "",
-                                        tint = Color.Gray,
-                                        modifier = Modifier
-                                            .size(32.dp)
-                                            .align(Alignment.CenterHorizontally)
-                                    )
-                                    Text(
-                                        text = "Location Not Found",
-                                        fontFamily = robotoFamily,
-                                        fontStyle = FontStyle.Normal,
-                                        color = Color.Gray
-                                    )
-
-                                }
+                                LocationNotFound()
                             } else {
                                 LazyColumn {
                                     items(searchBarValue.searched.data) {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.KeyboardArrowLeft
 import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.material.icons.outlined.Search
+import androidx.compose.material.icons.rounded.Place
 import androidx.compose.material3.Divider
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
@@ -77,7 +78,6 @@ import com.cornellappdev.transit.ui.viewmodels.LocationUIState
 import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
 import com.cornellappdev.transit.ui.viewmodels.SearchBarUIState
 import com.cornellappdev.transit.util.TimeUtils
-import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -88,10 +88,6 @@ import java.util.Date
  * Composable for the route screen, which specifies a location, destination, and routes between them
  */
 @RequiresApi(Build.VERSION_CODES.O)
-@OptIn(
-    ExperimentalPermissionsApi::class, ExperimentalMaterial3Api::class,
-    ExperimentalMaterialApi::class
-)
 @Composable
 fun RouteScreen(
     navController: NavController,
@@ -579,7 +575,17 @@ private fun RouteList(
 ) {
     when (lastRouteResponse) {
         is ApiResponse.Error -> {
-            Text("Error")
+            Text(
+                text = "No Routes Found",
+                fontFamily = robotoFamily,
+                fontWeight = FontWeight.Normal,
+                color = MetadataGray,
+                fontSize = 24.sp,
+                modifier = Modifier
+                    .padding(12.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center
+            )
         }
 
         is ApiResponse.Pending -> {
@@ -813,7 +819,22 @@ private fun RouteOptionsSearchSheet(
                         when (searchBarValue.searched) {
                             is ApiResponse.Error -> {
                                 item {
-                                    Text("Error")
+                                    Icon(
+                                        imageVector = Icons.Rounded.Place,
+                                        contentDescription = "",
+                                        tint = Color.Gray,
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .align(Alignment.CenterHorizontally)
+                                    )
+                                }
+                                item {
+                                    Text(
+                                        text = "Location Not Found",
+                                        fontFamily = robotoFamily,
+                                        fontStyle = FontStyle.Normal,
+                                        color = Color.Gray
+                                    )
                                 }
                             }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -744,7 +744,18 @@ private fun RouteOptionsSearchSheet(
                         modifier = Modifier.clickable { routeViewModel.onQueryChange("") })
                 }
             )
-            LazyColumn {
+            LazyColumn(
+                modifier = Modifier.fillMaxSize(),
+                verticalArrangement = when {
+                    searchBarValue is SearchBarUIState.RecentAndFavorites ||
+                            (searchBarValue is SearchBarUIState.Query &&
+                                    searchBarValue.searched is ApiResponse.Success &&
+                                    searchBarValue.searched.data.isNotEmpty()) -> Arrangement.Top
+
+                    else -> Arrangement.Center
+                },
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
                 when (searchBarValue) {
                     is SearchBarUIState.RecentAndFavorites -> {
                         item {
@@ -875,6 +886,26 @@ private fun RouteOptionsSearchSheet(
                                             }
                                             onItemClicked()
                                         })
+                                }
+                                if (searchBarValue.searched.data.isEmpty()) {
+                                    item {
+                                        Icon(
+                                            imageVector = Icons.Rounded.Place,
+                                            contentDescription = "",
+                                            tint = Color.Gray,
+                                            modifier = Modifier
+                                                .size(32.dp)
+                                                .align(Alignment.CenterHorizontally)
+                                        )
+                                    }
+                                    item {
+                                        Text(
+                                            text = "Location Not Found",
+                                            fontFamily = robotoFamily,
+                                            fontStyle = FontStyle.Normal,
+                                            color = Color.Gray
+                                        )
+                                    }
                                 }
                             }
                         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.ModalBottomSheetLayout
 import androidx.compose.material.ModalBottomSheetState
@@ -582,7 +583,16 @@ private fun RouteList(
         }
 
         is ApiResponse.Pending -> {
-            Text("Pending")
+            Box(
+                modifier = Modifier
+                    .fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(32.dp),
+                    color = TransitBlue,
+                )
+            }
         }
 
         is ApiResponse.Success -> {
@@ -728,7 +738,6 @@ private fun RouteOptionsSearchSheet(
                         modifier = Modifier.clickable { routeViewModel.onQueryChange("") })
                 }
             )
-
             LazyColumn {
                 when (searchBarValue) {
                     is SearchBarUIState.RecentAndFavorites -> {
@@ -810,7 +819,13 @@ private fun RouteOptionsSearchSheet(
 
                             is ApiResponse.Pending -> {
                                 item {
-                                    Text("Pending")
+                                    CircularProgressIndicator(
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .align(Alignment.CenterHorizontally),
+                                        color = TransitBlue,
+                                    )
+
                                 }
                             }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -744,20 +744,107 @@ private fun RouteOptionsSearchSheet(
                         modifier = Modifier.clickable { routeViewModel.onQueryChange("") })
                 }
             )
-            LazyColumn(
-                modifier = Modifier.fillMaxSize(),
-                verticalArrangement = when {
-                    searchBarValue is SearchBarUIState.RecentAndFavorites ||
-                            (searchBarValue is SearchBarUIState.Query &&
-                                    searchBarValue.searched is ApiResponse.Success &&
-                                    searchBarValue.searched.data.isNotEmpty()) -> Arrangement.Top
+            when (searchBarValue) {
+                is SearchBarUIState.Query -> {
+                    when (searchBarValue.searched) {
+                        ApiResponse.Error -> {
+                            Column(
+                                modifier = Modifier.fillMaxSize(),
+                                verticalArrangement = Arrangement.Center,
+                                horizontalAlignment = Alignment.CenterHorizontally
+                            ) {
+                                Icon(
+                                    imageVector = Icons.Rounded.Place,
+                                    contentDescription = "",
+                                    tint = Color.Gray,
+                                    modifier = Modifier
+                                        .size(32.dp)
+                                        .align(Alignment.CenterHorizontally)
+                                )
+                                Text(
+                                    text = "Location Not Found",
+                                    fontFamily = robotoFamily,
+                                    fontStyle = FontStyle.Normal,
+                                    color = Color.Gray
+                                )
 
-                    else -> Arrangement.Center
-                },
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                when (searchBarValue) {
-                    is SearchBarUIState.RecentAndFavorites -> {
+                            }
+                        }
+
+                        ApiResponse.Pending -> {
+                            Box(
+                                modifier = Modifier.fillMaxSize(),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(
+                                    modifier = Modifier
+                                        .size(32.dp),
+                                    color = TransitBlue,
+                                )
+                            }
+                        }
+
+                        is ApiResponse.Success -> {
+                            if (searchBarValue.searched.data.isEmpty()) {
+                                Column(
+                                    modifier = Modifier.fillMaxSize(),
+                                    verticalArrangement = Arrangement.Center,
+                                    horizontalAlignment = Alignment.CenterHorizontally
+                                ) {
+                                    Icon(
+                                        imageVector = Icons.Rounded.Place,
+                                        contentDescription = "",
+                                        tint = Color.Gray,
+                                        modifier = Modifier
+                                            .size(32.dp)
+                                            .align(Alignment.CenterHorizontally)
+                                    )
+                                    Text(
+                                        text = "Location Not Found",
+                                        fontFamily = robotoFamily,
+                                        fontStyle = FontStyle.Normal,
+                                        color = Color.Gray
+                                    )
+
+                                }
+                            } else {
+                                LazyColumn {
+                                    items(searchBarValue.searched.data) {
+                                        MenuItem(
+                                            type = it.type,
+                                            label = it.name,
+                                            sublabel = it.subLabel,
+                                            onClick = {
+                                                if (isStart) {
+                                                    routeViewModel.changeStartLocation(
+                                                        LocationUIState.Place(
+                                                            it.name,
+                                                            LatLng(it.latitude, it.longitude)
+                                                        )
+                                                    )
+                                                } else {
+                                                    routeViewModel.changeEndLocation(
+                                                        LocationUIState.Place(
+                                                            it.name,
+                                                            LatLng(it.latitude, it.longitude)
+                                                        )
+                                                    )
+                                                }
+                                                onItemClicked()
+                                            })
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                is SearchBarUIState.RecentAndFavorites -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.Top,
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
                         item {
                             Text(
                                 "Favorites",
@@ -825,95 +912,9 @@ private fun RouteOptionsSearchSheet(
                             )
                         }
                     }
-
-                    is SearchBarUIState.Query -> {
-                        when (searchBarValue.searched) {
-                            is ApiResponse.Error -> {
-                                item {
-                                    Icon(
-                                        imageVector = Icons.Rounded.Place,
-                                        contentDescription = "",
-                                        tint = Color.Gray,
-                                        modifier = Modifier
-                                            .size(32.dp)
-                                            .align(Alignment.CenterHorizontally)
-                                    )
-                                }
-                                item {
-                                    Text(
-                                        text = "Location Not Found",
-                                        fontFamily = robotoFamily,
-                                        fontStyle = FontStyle.Normal,
-                                        color = Color.Gray
-                                    )
-                                }
-                            }
-
-                            is ApiResponse.Pending -> {
-                                item {
-                                    CircularProgressIndicator(
-                                        modifier = Modifier
-                                            .size(32.dp)
-                                            .align(Alignment.CenterHorizontally),
-                                        color = TransitBlue,
-                                    )
-
-                                }
-                            }
-
-                            is ApiResponse.Success -> {
-
-                                items(searchBarValue.searched.data) {
-                                    MenuItem(
-                                        type = it.type,
-                                        label = it.name,
-                                        sublabel = it.subLabel,
-                                        onClick = {
-                                            if (isStart) {
-                                                routeViewModel.changeStartLocation(
-                                                    LocationUIState.Place(
-                                                        it.name,
-                                                        LatLng(it.latitude, it.longitude)
-                                                    )
-                                                )
-                                            } else {
-                                                routeViewModel.changeEndLocation(
-                                                    LocationUIState.Place(
-                                                        it.name,
-                                                        LatLng(it.latitude, it.longitude)
-                                                    )
-                                                )
-                                            }
-                                            onItemClicked()
-                                        })
-                                }
-                                if (searchBarValue.searched.data.isEmpty()) {
-                                    item {
-                                        Icon(
-                                            imageVector = Icons.Rounded.Place,
-                                            contentDescription = "",
-                                            tint = Color.Gray,
-                                            modifier = Modifier
-                                                .size(32.dp)
-                                                .align(Alignment.CenterHorizontally)
-                                        )
-                                    }
-                                    item {
-                                        Text(
-                                            text = "Location Not Found",
-                                            fontFamily = robotoFamily,
-                                            fontStyle = FontStyle.Normal,
-                                            color = Color.Gray
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    }
-
                 }
-
             }
         }
     }
+
 }


### PR DESCRIPTION
## Overview
Added loading and error screens throughout the app

## Changes Made
- Added loading and error states to search bars in `HomeScreen`, `AddFavoritesBottomSheet` and  `RouteScreen` and route display in `RouteScreen`
- Rearrange code in these sections for readability and better organization

## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
- Pixel 3a emulator
- Samsung A14 physical emulator

## Related PRs or Issues
<!-- List related PRs against other branches/repositories. -->
Fixes #50 
## Screenshots 
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Recording of all three sear</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

https://github.com/user-attachments/assets/da153c6d-113e-44d8-9b79-29d3411e35b8


</details>
