### PR TITLE
Change distance for meters to miles

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/Route.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Route.kt
@@ -33,12 +33,14 @@ data class Direction(
     @Json(name = "type") private val directionType: String, // "walk" or "depart"
     @Json(name = "stops") val stops: List<DirectionStop>,
     @Json(name = "endTime") val endTime: String,
-    @Json(name = "distance") val distance: String,
+    @Json(name = "distance") val distanceMeters: String,
     @Json(name = "startTime") val startTime: String,
     @Json(name = "name") val name: String
 ) {
     val type
         get() = if (directionType == "walk") DirectionType.WALK else DirectionType.DEPART
+    val distance: String
+        get() = "%.2f".format(distanceMeters.toDouble() / 1609.34)
 }
 
 

--- a/app/src/main/java/com/cornellappdev/transit/models/Route.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Route.kt
@@ -1,6 +1,6 @@
 package com.cornellappdev.transit.models
 
-import com.cornellappdev.transit.util.StringUtils.toMiles
+import com.cornellappdev.transit.util.StringUtils.fromMetersToMiles
 import com.google.android.gms.maps.model.LatLng
 import com.squareup.moshi.Json
 
@@ -40,7 +40,7 @@ data class Direction(
     val type
         get() = if (directionType == "walk") DirectionType.WALK else DirectionType.DEPART
     val distance: String
-        get() = distanceMeters.toMiles()
+        get() = distanceMeters.fromMetersToMiles()
 }
 
 

--- a/app/src/main/java/com/cornellappdev/transit/models/Route.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/Route.kt
@@ -1,8 +1,8 @@
 package com.cornellappdev.transit.models
 
+import com.cornellappdev.transit.util.StringUtils.toMiles
 import com.google.android.gms.maps.model.LatLng
 import com.squareup.moshi.Json
-
 
 /**
  * Data class representing a stop in a list of directions
@@ -40,7 +40,7 @@ data class Direction(
     val type
         get() = if (directionType == "walk") DirectionType.WALK else DirectionType.DEPART
     val distance: String
-        get() = "%.2f".format(distanceMeters.toDouble() / 1609.34)
+        get() = distanceMeters.toMiles()
 }
 
 

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -3,7 +3,7 @@ package com.cornellappdev.transit.models
 import androidx.compose.ui.graphics.Color
 import com.cornellappdev.transit.ui.theme.LateRed
 import com.cornellappdev.transit.ui.theme.LiveGreen
-import com.cornellappdev.transit.util.StringUtils.toMiles
+import com.cornellappdev.transit.util.StringUtils.fromMetersToMiles
 import com.cornellappdev.transit.util.TimeUtils
 import java.util.Locale
 
@@ -43,7 +43,7 @@ data class Transport(
     val directionList: List<Direction>
 ) {
     val distance: String
-        get() = distanceMeters.toMiles()
+        get() = distanceMeters.fromMetersToMiles()
 }
 
 /**

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -34,13 +34,16 @@ data class Transport(
     val startTime: String,
     val arriveTime: String,
     val lateness: BusLateness,
-    val distance: String,
+    val distanceMeters: String,
     val start: String,
     val end: String,
     val walkOnly: Boolean,
     val timeToBoard: Int,
     val directionList: List<Direction>
-)
+) {
+    val distance: String
+        get() = "%.1f".format(distanceMeters.toDouble() / 1609.34)
+}
 
 /**
  * Create a Transport object from Route
@@ -54,7 +57,7 @@ fun Route.toTransport(): Transport {
     return Transport(
         startTime = TimeUtils.getHHMM(this.departureTime),
         arriveTime = TimeUtils.getHHMM(this.arrivalTime),
-        distance = String.format(Locale.US, "%.1f", this.travelDistance),
+        distanceMeters = String.format(Locale.US, "%.1f", this.travelDistance),
         start = this.startName,
         end = this.endName,
         walkOnly = !containsBus,

--- a/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/RouteModels.kt
@@ -3,6 +3,7 @@ package com.cornellappdev.transit.models
 import androidx.compose.ui.graphics.Color
 import com.cornellappdev.transit.ui.theme.LateRed
 import com.cornellappdev.transit.ui.theme.LiveGreen
+import com.cornellappdev.transit.util.StringUtils.toMiles
 import com.cornellappdev.transit.util.TimeUtils
 import java.util.Locale
 
@@ -42,7 +43,7 @@ data class Transport(
     val directionList: List<Direction>
 ) {
     val distance: String
-        get() = "%.1f".format(distanceMeters.toDouble() / 1609.34)
+        get() = distanceMeters.toMiles()
 }
 
 /**

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -416,7 +416,7 @@ private fun PreviewRouteCellBusAndWalk() {
         Transport(
             startTime = "12:42AM",
             arriveTime = "12:49AM",
-            distance = "0.2",
+            distanceMeters = "0.2",
             start = "Gates Hall",
             end = "Upson Hall",
             timeToBoard = 7,
@@ -432,7 +432,7 @@ private fun PreviewRouteCellBusAndWalk() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
                     name = "Gates Hall"
@@ -447,7 +447,7 @@ private fun PreviewRouteCellBusAndWalk() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
                     name = "Duffield Hall"
@@ -465,7 +465,7 @@ private fun PreviewRouteCellMultBusesAndWalk() {
         Transport(
             startTime = "12:42AM",
             arriveTime = "12:49AM",
-            distance = "0.2",
+            distanceMeters = "0.2",
             start = "Gates Hall",
             end = "Upson Hall",
             timeToBoard = 7,
@@ -481,7 +481,7 @@ private fun PreviewRouteCellMultBusesAndWalk() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
                     name = "Gates Hall"
@@ -496,7 +496,7 @@ private fun PreviewRouteCellMultBusesAndWalk() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
                     name = "Phillips Hall"
@@ -511,7 +511,7 @@ private fun PreviewRouteCellMultBusesAndWalk() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "depart",
                     name = "Duffield Hall"
@@ -529,7 +529,7 @@ private fun PreviewRouteCellWalkOnly() {
         Transport(
             startTime = "12:42AM",
             arriveTime = "12:49AM",
-            distance = "0.1",
+            distanceMeters = "0.1",
             lateness = BusLateness.NONE,
             start = "Gates Hall",
             end = "Upson Hall",
@@ -546,7 +546,7 @@ private fun PreviewRouteCellWalkOnly() {
                     path = listOf(),
                     stops = listOf(),
                     endTime = "12:49AM",
-                    distance = "0.2",
+                    distanceMeters = "0.2",
                     startTime = "12:42AM",
                     directionType = "walk",
                     name = "Gates Hall"

--- a/app/src/main/java/com/cornellappdev/transit/util/StringUtils.kt
+++ b/app/src/main/java/com/cornellappdev/transit/util/StringUtils.kt
@@ -23,7 +23,7 @@ object StringUtils {
         return URLDecoder.decode(this, StandardCharsets.UTF_8.toString())
     }
 
-    fun String.toMiles(): String {
+    fun String.fromMetersToMiles(): String {
         return "%.1f".format(this.toDouble() / 1609.34)
     }
 }

--- a/app/src/main/java/com/cornellappdev/transit/util/StringUtils.kt
+++ b/app/src/main/java/com/cornellappdev/transit/util/StringUtils.kt
@@ -19,7 +19,11 @@ object StringUtils {
     /**
      * Convert a string from a URL safe string to a normal string
      */
-    fun String.fromURLString() : String {
+    fun String.fromURLString(): String {
         return URLDecoder.decode(this, StandardCharsets.UTF_8.toString())
+    }
+
+    fun String.toMiles(): String {
+        return "%.1f".format(this.toDouble() / 1609.34)
     }
 }


### PR DESCRIPTION
## Overview

Change the distances throughout the app from meters to miles

## Changes Made

- changed the name of the `distance` field in `Direction` and `Transport` to `distanceMeters` and added a field `distance` that calculates the mile distance from the meter distance
- Adjusted all usages of `distance` accordingly

## Test Coverage

Samsung A14 physicl emulator

## Screenshots (delete if not applicable)
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Before</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

  ![WhatsApp Image 2025-02-22 at 7 53 42 PM](https://github.com/user-attachments/assets/c6853fc5-37f4-479e-b2b2-640af927745e)

</details>

<details>
  <summary>After</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![WhatsApp Image 2025-02-22 at 7 53 42 PM (1)](https://github.com/user-attachments/assets/dd902001-69b0-45cd-b861-476853e70681)

</details>
