### PR TITLE
AddFavorites Search Bar Issue fixes

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -131,10 +131,12 @@ fun AddFavoritesSearchSheet(
                 ),
                 leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
                 trailingIcon = {
-                    Icon(
-                        Icons.Outlined.Clear,
-                        "Clear",
-                        modifier = Modifier.clickable { homeViewModel.onAddQueryChange("") })
+                    if (addSearchBarValue.isNotEmpty()) {
+                        Icon(
+                            Icons.Outlined.Clear,
+                            "Clear",
+                            modifier = Modifier.clickable { homeViewModel.onAddQueryChange("") })
+                    }
                 },
                 placeholder = { Text(text = "Search for a stop to add") },
                 modifier = Modifier.border(

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -1,6 +1,8 @@
 package com.cornellappdev.transit.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,7 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Clear
 import androidx.compose.material.icons.outlined.Search
 import androidx.compose.material3.DockedSearchBar
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -128,8 +130,19 @@ fun AddFavoritesSearchSheet(
                     dividerColor = DividerGray,
                 ),
                 leadingIcon = { Icon(Icons.Outlined.Search, "Search") },
-                trailingIcon = { Icon(Icons.Outlined.Info, "Info") },
-                placeholder = { Text(text = "Search for a stop to add") }
+                trailingIcon = {
+                    Icon(
+                        Icons.Outlined.Clear,
+                        "Clear",
+                        modifier = Modifier.clickable { homeViewModel.onAddQueryChange("") })
+                },
+                placeholder = { Text(text = "Search for a stop to add") },
+                modifier = Modifier.border(
+                    width = 2.dp,
+                    color = DividerGray,
+                    shape = RoundedCornerShape(size = 8.dp)
+                )
+
             ) {
                 when (placeQueryResponse) {
                     is ApiResponse.Error -> {


### PR DESCRIPTION
## Overview

Added a border to the search bar and replaced the trailing icon.

## Changes Made

- Added a border to the add favorites search bar
- Removed the info icon at the end of the search bar
- Added a clear icon to the end of the search bar to clear the query

## Test Coverage

Samsung A14 physical emulator

## Related PRs or Issues (delete if not applicable)

Fixes #72 
Fixes #73 

## Screenshots (delete if not applicable)
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Add Favorites Search Sheet</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![WhatsApp Image 2025-02-26 at 5 42 54 PM](https://github.com/user-attachments/assets/917554bd-3798-480f-a50f-a35af62a2881)

</details>
