### PR TITLE
Fix flickering error issue

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
+++ b/app/src/main/java/com/cornellappdev/transit/models/SelectedRouteRepository.kt
@@ -1,6 +1,7 @@
 package com.cornellappdev.transit.models
 
 import com.cornellappdev.transit.ui.viewmodels.LocationUIState
+import com.cornellappdev.transit.ui.viewmodels.SelectedRouteState
 import com.google.android.gms.maps.model.LatLng
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -10,38 +11,48 @@ import javax.inject.Singleton
 @Singleton
 class SelectedRouteRepository @Inject constructor() {
 
-    private val _startPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
-        LocationUIState.CurrentLocation
+    private val _selectedRoute: MutableStateFlow<SelectedRouteState> = MutableStateFlow(
+        SelectedRouteState(
+            LocationUIState.CurrentLocation,
+            LocationUIState.CurrentLocation
+        )
     )
 
-    private val _destPlace: MutableStateFlow<LocationUIState> = MutableStateFlow(
-        LocationUIState.CurrentLocation
-    )
-
     /**
-     * Pair of the name of the starting location and the coordinates
+     * The selected route parameters in route options
      */
-    val startPlace = _startPlace.asStateFlow()
+    val selectedRoute = _selectedRoute.asStateFlow()
 
     /**
-     * Pair of the name of the ending location and the coordinates
-     */
-    val destPlace = _destPlace.asStateFlow()
-
-    /**
-     * Change the start location [_startPlace]
+     * Change the start location in [_selectedRoute]
      * @param location The new starting location as a LocationUIState
      */
     fun setStartPlace(location: LocationUIState) {
-        _startPlace.value = location
+        _selectedRoute.value = SelectedRouteState(
+            location,
+            _selectedRoute.value.endPlace
+        )
     }
 
     /**
-     * Change the destination location [_destPlace]
+     * Change the destination location in [_selectedRoute]
      * @param location The new destination location as a LocationUIState
      */
     fun setDestPlace(location: LocationUIState) {
-        _destPlace.value = location
+        _selectedRoute.value = SelectedRouteState(
+            _selectedRoute.value.startPlace,
+            location
+        )
+    }
+
+    /**
+     * Swap start and destination locations
+     */
+    fun swapPlaces() {
+        _selectedRoute.value = SelectedRouteState(
+            _selectedRoute.value.endPlace,
+            _selectedRoute.value.startPlace
+        )
     }
 
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -99,8 +99,7 @@ fun RouteScreen(
     routeViewModel: RouteViewModel
 ) {
 
-    val startLocation = routeViewModel.startPlace.collectAsState().value
-    val endLocation = routeViewModel.destPlace.collectAsState().value
+    val selectedRoute = routeViewModel.selectedRoute.collectAsState().value
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -167,8 +166,8 @@ fun RouteScreen(
                 routeViewModel = routeViewModel,
                 navController = navController,
                 coroutineScope = coroutineScope,
-                startLocation = startLocation,
-                endLocation = endLocation,
+                startLocation = selectedRoute.startPlace,
+                endLocation = selectedRoute.endPlace,
                 lastRoute = lastRoute,
                 startSheetState = startSheetState,
                 destSheetState = destSheetState

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/RouteViewModel.kt
@@ -165,7 +165,7 @@ class RouteViewModel @Inject constructor(
             // Every time startPlace, destPlace, or arriveBy changes, make a route request
             combine(startPlace, destPlace, arriveByFlow) { start, dest, arriveBy ->
                 Triple(start, dest, arriveBy)
-            }.collect {
+            }.debounce(50L).collect {
                 val startState = it.first
                 val endState = it.second
                 val arriveByState = it.third

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/SelectedRouteState.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/SelectedRouteState.kt
@@ -1,0 +1,9 @@
+package com.cornellappdev.transit.ui.viewmodels
+
+/**
+ * Class wrapping the pair of start location and end location for route searching
+ */
+data class SelectedRouteState(
+    val startPlace: LocationUIState,
+    val endPlace: LocationUIState
+)


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
<!-- Summarize your changes here. -->
Fixes flickering error when swapping start and destination on Route screen.
## Changes Made
<!-- Include details of what your changes actually are and how it is intended to work. -->
Presumed cause: when we swap start and destination, we change swap start to dest and then dest to start sequentially. In between this non-atomic swap, a call to backend is made which immediately fails, causing the error flicker.

Adding a debounce of 50ms before the HTTP request allows the swap to fully complete before we make a bad request.
## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
## Next Steps (delete if not applicable)
<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
## Related PRs or Issues (delete if not applicable)
<!-- List related PRs against other branches/repositories. -->
Fixes #75 
## Screenshots (delete if not applicable)
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
[swap.webm](https://github.com/user-attachments/assets/6d23db69-404b-4e7c-82ef-1ba0c504bec0)
