### PR TITLE
Fix duplicate stop name

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/RouteCell.kt
@@ -95,7 +95,11 @@ fun RouteCell(transport: Transport) {
                     SingleRoute(
                         isBus = direction.type == DirectionType.DEPART,
                         walkOnly = transport.walkOnly,
-                        stopName = direction.name,
+                        stopName = when {
+                            index == 0 -> transport.start
+                            direction.type == DirectionType.WALK -> transport.directionList[index - 1].stops.last().name
+                            else -> direction.name
+                        },
                         distance = if (index == 0) direction.distance else null,
                         busLine = direction.routeId
 


### PR DESCRIPTION
## Overview
<!-- Summarize your changes here. -->

The route cell does not have repeated start and end stops.

## Changes Made
<!-- Include details of what your changes actually are and how it is intended to work. -->
- display the start location of the `Transport` object for the first stop
- display the end location of the previous bus direction for any walk direction after a bus direction
- display the direction name otherwise

## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->

Samsung A14 physical emulator

## Related PRs or Issues 
<!-- List related PRs against other branches/repositories. -->

Fixes #89 

## Screenshots 
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Route Details Screen</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

![image](https://github.com/user-attachments/assets/7ad2af90-9f06-4177-aea6-87142b1ad46e)

</details>
