### PR TITLE
Clear all search bars when inactive

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -39,7 +39,6 @@ fun NavigationController(
         }
 
         composable("route") {
-            homeViewModel.onQueryChange("")
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -1,6 +1,5 @@
 package com.cornellappdev.transit.ui
 
-import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -40,6 +39,7 @@ fun NavigationController(
         }
 
         composable("route") {
+            homeViewModel.onQueryChange("")
             RouteScreen(navController = navController, routeViewModel = routeViewModel)
         }
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -170,6 +169,10 @@ fun HomeScreen(
 
     // Search bar active/inactive
     var searchActive by remember { mutableStateOf(false) }
+
+    if (!searchActive) {
+        homeViewModel.onQueryChange("")
+    }
 
     Box(
         modifier = Modifier
@@ -363,6 +366,7 @@ fun HomeScreen(
             ) {
                 scope.launch {
                     addSheetState.bottomSheetState.hide()
+                    homeViewModel.onAddQueryChange("")
                 }
             }
         },

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -211,7 +211,10 @@ fun HomeScreen(
                             Icon(
                                 Icons.Outlined.Info,
                                 "Info",
-                                Modifier.clickable { navController.navigate("settings") },
+                                Modifier.clickable {
+                                    homeViewModel.onQueryChange("")
+                                    navController.navigate("settings")
+                                },
                                 tint = IconGray
                             )
                         },
@@ -292,6 +295,7 @@ fun HomeScreen(
                                                             )
                                                         )
                                                     )
+                                                    homeViewModel.onQueryChange("")
                                                     navController.navigate("route")
                                                 })
 


### PR DESCRIPTION
## Overview

Both search bars on the home screen are cleared when inactive.

## Changes Made
<!-- Include details of what your changes actually are and how it is intended to work. -->
- Main search bar is cleared when navigated to the route or settings screen, and when inactive
- Add favorites search bar is cleared when "cancel" is pressed.

## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Pixel 3a emulator

## Related PRs or Issues
<!-- List related PRs against other branches/repositories. -->
Fixes #95 
Fixes #96 
Fixes #97

## Screenshots
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
<details>
  <summary>Search Bars</summary>
  <!-- Insert file link here. Newlines above and below your link are necessary for this to work. -->

[search bars.webm](https://github.com/user-attachments/assets/d9d9f906-404d-4996-839c-6e0940c5b21a)

</details>
