### PR TITLE
Home Screen adjustments and improvements

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -52,21 +52,19 @@ import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
 
 /**
  * Contents of AddFavorites BottomSheet
- * @param homeViewModel the homeViewModel used in the app
  * @param cancelOnClick The function to run when the cancel button is clicked
  * @param onItemClick The function to run when a menu item from a search is clicked
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddFavoritesSearchSheet(
-    homeViewModel: HomeViewModel,
+    addSearchBarValue: String,
+    placeQueryResponse: ApiResponse<List<Place>>,
+    onQueryChange: (String) -> Unit,
+    onClearChange: () -> Unit,
     cancelOnClick: () -> Unit,
     onItemClick: (Place) -> Unit,
 ) {
-
-    val addSearchBarValue = homeViewModel.addSearchQuery.collectAsState().value
-
-    val placeQueryResponse = homeViewModel.placeQueryFlow.collectAsState().value
 
     var addSearchActive by remember { mutableStateOf(false) }
 
@@ -125,10 +123,12 @@ fun AddFavoritesSearchSheet(
                 inputField = {
                     SearchBarDefaults.InputField(
                         query = addSearchBarValue,
-                        onQueryChange = { s -> homeViewModel.onAddQueryChange(s) },
-                        onSearch = { addSearchActive = false; homeViewModel.onSearch(it) },
+                        onQueryChange = { s -> onQueryChange(s) },
+                        onSearch = {},
                         expanded = addSearchActive,
-                        onExpandedChange = { b -> addSearchActive = b },
+                        onExpandedChange = { b ->
+                            addSearchActive = b
+                        },
                         placeholder = { Text(text = "Search for a stop to add") },
                         leadingIcon = { Icon(Icons.Outlined.Search, "Search", tint = IconGray) },
                         colors = SearchBarDefaults.inputFieldColors(
@@ -142,7 +142,7 @@ fun AddFavoritesSearchSheet(
                                 Icon(
                                     Icons.Outlined.Clear,
                                     "Clear",
-                                    modifier = Modifier.clickable { homeViewModel.onAddQueryChange("") })
+                                    modifier = Modifier.clickable { onClearChange() })
                             }
                         },
                         modifier = Modifier.border(

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.theme.DividerGray
 import com.cornellappdev.transit.ui.theme.IconGray
@@ -53,13 +54,14 @@ import com.cornellappdev.transit.ui.viewmodels.HomeViewModel
  * Contents of AddFavorites BottomSheet
  * @param homeViewModel the homeViewModel used in the app
  * @param cancelOnClick The function to run when the cancel button is clicked
+ * @param onItemClick The function to run when a menu item from a search is clicked
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AddFavoritesSearchSheet(
     homeViewModel: HomeViewModel,
-    favoritesViewModel: FavoritesViewModel = hiltViewModel(),
     cancelOnClick: () -> Unit,
+    onItemClick: (Place) -> Unit,
 ) {
 
     val addSearchBarValue = homeViewModel.addSearchQuery.collectAsState().value
@@ -67,8 +69,6 @@ fun AddFavoritesSearchSheet(
     val placeQueryResponse = homeViewModel.placeQueryFlow.collectAsState().value
 
     var addSearchActive by remember { mutableStateOf(false) }
-
-    val favorites = favoritesViewModel.favoritesStops.collectAsState().value
 
     val keyboardController = LocalSoftwareKeyboardController.current
 
@@ -160,36 +160,10 @@ fun AddFavoritesSearchSheet(
                     dividerColor = DividerGray,
                 )
             ) {
-                when (placeQueryResponse) {
-                    is ApiResponse.Error -> {
-                        LocationNotFound()
-                    }
-
-                    ApiResponse.Pending -> {
-                        ProgressCircle()
-                    }
-
-                    is ApiResponse.Success -> {
-                        if (placeQueryResponse.data.isEmpty()) {
-                            LocationNotFound()
-                        }
-                        LazyColumn {
-                            items(placeQueryResponse.data) {
-                                MenuItem(
-                                    type = it.type,
-                                    label = it.name,
-                                    sublabel = it.subLabel,
-                                    onClick = {
-                                        if (it !in favorites) {
-                                            favoritesViewModel.addFavorite(it)
-                                            keyboardController?.hide()
-                                        }
-                                    })
-                            }
-                        }
-                    }
-                }
-
+                LoadingLocationItems(
+                    placeQueryResponse,
+                    onClick = { onItemClick(it); keyboardController?.hide() }
+                )
             }
         }
     }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/AddFavoritesSearchSheet.kt
@@ -123,11 +123,11 @@ fun AddFavoritesSearchSheet(
                 inputField = {
                     SearchBarDefaults.InputField(
                         query = addSearchBarValue,
-                        onQueryChange = { s -> onQueryChange(s) },
-                        onSearch = {},
+                        onQueryChange = onQueryChange,
+                        onSearch = {}, // Search occurs automatically when typing
                         expanded = addSearchActive,
-                        onExpandedChange = { b ->
-                            addSearchActive = b
+                        onExpandedChange = { isExpanded ->
+                            addSearchActive = isExpanded
                         },
                         placeholder = { Text(text = "Search for a stop to add") },
                         leadingIcon = { Icon(Icons.Outlined.Search, "Search", tint = IconGray) },
@@ -153,7 +153,7 @@ fun AddFavoritesSearchSheet(
                     )
                 },
                 expanded = addSearchActive,
-                onExpandedChange = { b -> addSearchActive = b },
+                onExpandedChange = { isExpanded -> addSearchActive = isExpanded },
                 shape = RoundedCornerShape(size = 8.dp),
                 colors = SearchBarDefaults.colors(
                     containerColor = Color.White,

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -32,14 +32,13 @@ import com.google.android.gms.maps.model.LatLng
  * Contents of BottomSheet in HomeScreen
  * @param editText The text in the edit/done button
  * @param editState The state of the lazyRow, whether it's currently being edited or not
- * @param data The data the lazyRow contains
- * @param onclick The Function to run when the edit/done button is clicked
+ * @param onClick The Function to run when the edit/done button is clicked
  */
 @Composable
 fun BottomSheetContent(
     editText: String,
     editState: Boolean,
-    onclick: () -> Unit,
+    onClick: () -> Unit,
     addOnClick: () -> Unit,
     removeOnClick: () -> Unit,
     changeEndLocation: (LocationUIState) -> Unit,
@@ -70,7 +69,7 @@ fun BottomSheetContent(
             Spacer(modifier = Modifier.weight(1f))
             Text(
                 text = editText,
-                modifier = Modifier.clickable(onClick = onclick),
+                modifier = Modifier.clickable(onClick = onClick),
                 color = TransitBlue,
                 textAlign = TextAlign.Right,
                 fontSize = 14.sp,
@@ -79,7 +78,7 @@ fun BottomSheetContent(
             )
         }
 
-        LazyRow(modifier = Modifier.padding(bottom = 20.dp)) {
+        LazyRow(modifier = Modifier.padding(bottom = 12.dp)) {
             item {
                 LocationItem(
                     image = painterResource(id = R.drawable.ellipse),

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
+import com.cornellappdev.transit.models.Place
 import com.cornellappdev.transit.ui.theme.TransitBlue
 import com.cornellappdev.transit.ui.theme.robotoFamily
 import com.cornellappdev.transit.ui.viewmodels.FavoritesViewModel
@@ -39,15 +40,11 @@ fun BottomSheetContent(
     editText: String,
     editState: Boolean,
     onClick: () -> Unit,
+    favoritesData: Set<Place>,
+    itemOnClick: (Place) -> Unit,
     addOnClick: () -> Unit,
-    removeOnClick: () -> Unit,
-    changeEndLocation: (LocationUIState) -> Unit,
-    favoritesViewModel: FavoritesViewModel = hiltViewModel(),
-    navController: NavController
+    removeOnClick: (Place) -> Unit,
 ) {
-
-    val data = favoritesViewModel.favoritesStops.collectAsState().value.toList()
-
     Column {
         Row(
             modifier = Modifier
@@ -91,27 +88,16 @@ fun BottomSheetContent(
                     removeOnClick = {}
                 )
             }
-            items(data) {
+            items(favoritesData.toList()) {
                 LocationItem(
                     image = painterResource(id = R.drawable.location_icon),
                     editImage = painterResource(id = R.drawable.location_icon_edit),
                     label = it.name,
                     sublabel = "",
                     editing = editState,
-                    {
-                        changeEndLocation(
-                            LocationUIState.Place(
-                                it.name,
-                                LatLng(
-                                    it.latitude,
-                                    it.longitude
-                                )
-                            )
-                        )
-                        navController.navigate("route")
-                    },
+                    itemOnClick = { itemOnClick(it) },
                     addOnClick = {},
-                    removeOnClick = { favoritesViewModel.removeFavorite(it); removeOnClick() },
+                    removeOnClick = { removeOnClick(it) },
                 )
             }
         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/BottomSheetContent.kt
@@ -33,13 +33,13 @@ import com.google.android.gms.maps.model.LatLng
  * Contents of BottomSheet in HomeScreen
  * @param editText The text in the edit/done button
  * @param editState The state of the lazyRow, whether it's currently being edited or not
- * @param onClick The Function to run when the edit/done button is clicked
+ * @param onEditToggleClick The Function to run when the edit/done button is clicked
  */
 @Composable
 fun BottomSheetContent(
     editText: String,
     editState: Boolean,
-    onClick: () -> Unit,
+    onEditToggleClick: () -> Unit,
     favoritesData: Set<Place>,
     itemOnClick: (Place) -> Unit,
     addOnClick: () -> Unit,
@@ -66,7 +66,7 @@ fun BottomSheetContent(
             Spacer(modifier = Modifier.weight(1f))
             Text(
                 text = editText,
-                modifier = Modifier.clickable(onClick = onClick),
+                modifier = Modifier.clickable(onClick = onEditToggleClick),
                 color = TransitBlue,
                 textAlign = TextAlign.Right,
                 fontSize = 14.sp,

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/LoadingLocationItems.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/LoadingLocationItems.kt
@@ -1,0 +1,43 @@
+package com.cornellappdev.transit.ui.components
+
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import com.cornellappdev.transit.models.Place
+import com.cornellappdev.transit.networking.ApiResponse
+
+/**
+ * Composable that enumerates all potential outcomes of a search for places API call [searchResult].
+ * For outcomes with one or more place results, [onClick] is called when clicking on these places.
+ */
+@Composable
+fun LoadingLocationItems(searchResult: ApiResponse<List<Place>>, onClick: (Place) -> Unit) {
+    when (searchResult) {
+        is ApiResponse.Error -> {
+            LocationNotFound()
+        }
+
+        is ApiResponse.Pending -> {
+            ProgressCircle()
+        }
+
+        is ApiResponse.Success -> {
+            if (searchResult.data.isEmpty()) {
+                LocationNotFound()
+            } else {
+                LazyColumn {
+                    items(
+                        searchResult.data
+                    ) {
+                        MenuItem(
+                            type = it.type,
+                            label = it.name,
+                            sublabel = it.subLabel,
+                            onClick = { onClick(it) }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -25,6 +25,8 @@ fun SearchSuggestions(
     onFavoriteAdd: () -> Unit,
     onRecentClear: () -> Unit,
     onItemClick: (Place) -> Unit,
+    maxFavorites: Int = 4,
+    maxRecents: Int = 4
 ) {
     Column(
         modifier = Modifier
@@ -36,7 +38,7 @@ fun SearchSuggestions(
             buttonText = "Add",
             onClick = onFavoriteAdd
         )
-        favorites.take(minOf(4, favorites.size)).forEach {
+        favorites.take(minOf(maxFavorites, favorites.size)).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,
@@ -52,7 +54,7 @@ fun SearchSuggestions(
             buttonText = "Clear",
             onClick = onRecentClear
         )
-        recents.take(minOf(4, recents.size)).forEach {
+        recents.take(minOf(maxRecents, recents.size)).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -38,7 +38,7 @@ fun SearchSuggestions(
             buttonText = "Add",
             onClick = onFavoriteAdd
         )
-        favorites.take(minOf(maxFavorites, favorites.size)).forEach {
+        favorites.take(maxFavorites).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,
@@ -54,7 +54,7 @@ fun SearchSuggestions(
             buttonText = "Clear",
             onClick = onRecentClear
         )
-        recents.take(minOf(maxRecents, recents.size)).forEach {
+        recents.take(maxRecents).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,

--- a/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/components/SearchSuggestions.kt
@@ -24,10 +24,7 @@ fun SearchSuggestions(
     recents: List<Place>,
     onFavoriteAdd: () -> Unit,
     onRecentClear: () -> Unit,
-    changeStartLocation: (LocationUIState) -> Unit,
-    changeEndLocation: (LocationUIState) -> Unit,
-    navController: NavController,
-    onStopPressed: (Place) -> Unit,
+    onItemClick: (Place) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -39,26 +36,13 @@ fun SearchSuggestions(
             buttonText = "Add",
             onClick = onFavoriteAdd
         )
-        favorites.take(minOf(5, favorites.size)).forEach {
+        favorites.take(minOf(4, favorites.size)).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,
                 sublabel = it.subLabel,
                 onClick = {
-                    onStopPressed(it)
-                    changeStartLocation(
-                        LocationUIState.CurrentLocation
-                    )
-                    changeEndLocation(
-                        LocationUIState.Place(
-                            it.name,
-                            LatLng(
-                                it.latitude,
-                                it.longitude
-                            )
-                        )
-                    )
-                    navController.navigate("route")
+                    onItemClick(it)
                 }
             )
         }
@@ -68,26 +52,13 @@ fun SearchSuggestions(
             buttonText = "Clear",
             onClick = onRecentClear
         )
-        recents.forEach {
+        recents.take(minOf(4, recents.size)).forEach {
             MenuItem(
                 type = it.type,
                 label = it.name,
                 sublabel = it.subLabel,
                 onClick = {
-                    onStopPressed(it)
-                    changeStartLocation(
-                        LocationUIState.CurrentLocation
-                    )
-                    changeEndLocation(
-                        LocationUIState.Place(
-                            it.name,
-                            LatLng(
-                                it.latitude,
-                                it.longitude
-                            )
-                        )
-                    )
-                    navController.navigate("route")
+                    onItemClick(it)
                 }
             )
         }

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -51,6 +51,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.navigation.NavController
 import com.cornellappdev.transit.R
 import com.cornellappdev.transit.models.Place
+import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.components.AddFavoritesSearchSheet
 import com.cornellappdev.transit.ui.components.BottomSheetContent
 import com.cornellappdev.transit.ui.components.LoadingLocationItems
@@ -87,6 +88,7 @@ fun HomeScreen(
 ) {
     val scope = rememberCoroutineScope()
     val context = LocalContext.current
+    val localDensity = LocalDensity.current
 
     // Permissions dialog
     val permissionState = rememberPermissionState(Manifest.permission.ACCESS_FINE_LOCATION)
@@ -111,25 +113,29 @@ fun HomeScreen(
 
     //SheetState for FavoritesBottomSheet
     val favoritesSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = SheetState(
-            skipPartiallyExpanded = false,
-            initialValue = SheetValue.Expanded,
-            skipHiddenState = true,
-            density = LocalDensity.current
-        )
+        bottomSheetState = remember {
+            SheetState(
+                skipPartiallyExpanded = false,
+                initialValue = SheetValue.Expanded,
+                skipHiddenState = true,
+                density = localDensity
+            )
+        }
     )
 
     //sheetState for AddFavorites BottomSheet
     val addSheetState = rememberBottomSheetScaffoldState(
-        bottomSheetState = SheetState(
-            skipPartiallyExpanded = true,
-            initialValue = SheetValue.Hidden,
-            density = LocalDensity.current,
-            confirmValueChange = {
-                homeViewModel.onAddQueryChange("")
-                true
-            }
-        )
+        bottomSheetState = remember {
+            SheetState(
+                skipPartiallyExpanded = true,
+                initialValue = SheetValue.Hidden,
+                density = localDensity,
+                confirmValueChange = {
+                    homeViewModel.onAddQueryChange("")
+                    true
+                }
+            )
+        }
     )
 
     // Main search bar flow

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -187,9 +187,9 @@ fun HomeScreen(
             HomeScreenSearchBar(
                 searchBarValue,
                 onQueryChange = { s -> homeViewModel.onQueryChange(s) },
-                onSearch = {},
+                onSearch = {}, // Search occurs automatically when typing
                 expanded = searchActive,
-                onExpandedChange = { b -> searchActive = b },
+                onExpandedChange = { isExpanded -> searchActive = isExpanded },
                 onInfoClick = {
                     homeViewModel.onQueryChange("")
                     navController.navigate("settings")
@@ -203,20 +203,7 @@ fun HomeScreen(
                     homeViewModel.clearRecents()
                 },
                 onItemClick = {
-                    homeViewModel.addRecent(it)
-                    homeViewModel.changeStartLocation(
-                        LocationUIState.CurrentLocation
-                    )
-                    homeViewModel.changeEndLocation(
-                        LocationUIState.Place(
-                            it.name,
-                            LatLng(
-                                it.latitude,
-                                it.longitude
-                            )
-                        )
-                    )
-                    homeViewModel.onQueryChange("")
+                    homeViewModel.beginRouteOptions(it)
                     navController.navigate("route")
                 }
             )
@@ -241,7 +228,7 @@ fun HomeScreen(
                 editText = editText,
                 editState = editState,
                 favoritesData = favorites,
-                onClick = {
+                onEditToggleClick = {
                     editState = !editState
                     editText = if (editState) {
                         "Done"
@@ -266,15 +253,7 @@ fun HomeScreen(
                     favoritesViewModel.removeFavorite(it)
                 },
                 itemOnClick = {
-                    homeViewModel.changeEndLocation(
-                        LocationUIState.Place(
-                            it.name,
-                            LatLng(
-                                it.latitude,
-                                it.longitude
-                            )
-                        )
-                    )
+                    homeViewModel.beginRouteOptions(it)
                     navController.navigate("route")
                 }
             )

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/RouteScreen.kt
@@ -59,6 +59,7 @@ import com.cornellappdev.transit.models.toTransport
 import com.cornellappdev.transit.networking.ApiResponse
 import com.cornellappdev.transit.ui.components.CurrentLocationItem
 import com.cornellappdev.transit.ui.components.DatePicker
+import com.cornellappdev.transit.ui.components.LoadingLocationItems
 import com.cornellappdev.transit.ui.components.LocationNotFound
 import com.cornellappdev.transit.ui.components.MenuItem
 import com.cornellappdev.transit.ui.components.ProgressCircle
@@ -740,48 +741,27 @@ private fun RouteOptionsSearchSheet(
             )
             when (searchBarValue) {
                 is SearchBarUIState.Query -> {
-                    when (searchBarValue.searched) {
-                        ApiResponse.Error -> {
-                            LocationNotFound()
-                        }
-
-                        ApiResponse.Pending -> {
-                            ProgressCircle()
-                        }
-
-                        is ApiResponse.Success -> {
-                            if (searchBarValue.searched.data.isEmpty()) {
-                                LocationNotFound()
+                    LoadingLocationItems(
+                        searchBarValue.searched,
+                        onClick = {
+                            if (isStart) {
+                                routeViewModel.setStartPlace(
+                                    LocationUIState.Place(
+                                        it.name,
+                                        LatLng(it.latitude, it.longitude)
+                                    )
+                                )
                             } else {
-                                LazyColumn {
-                                    items(searchBarValue.searched.data) {
-                                        MenuItem(
-                                            type = it.type,
-                                            label = it.name,
-                                            sublabel = it.subLabel,
-                                            onClick = {
-                                                if (isStart) {
-                                                    routeViewModel.setStartPlace(
-                                                        LocationUIState.Place(
-                                                            it.name,
-                                                            LatLng(it.latitude, it.longitude)
-                                                        )
-                                                    )
-                                                } else {
-                                                    routeViewModel.setDestPlace(
-                                                        LocationUIState.Place(
-                                                            it.name,
-                                                            LatLng(it.latitude, it.longitude)
-                                                        )
-                                                    )
-                                                }
-                                                onItemClicked()
-                                            })
-                                    }
-                                }
+                                routeViewModel.setDestPlace(
+                                    LocationUIState.Place(
+                                        it.name,
+                                        LatLng(it.latitude, it.longitude)
+                                    )
+                                )
                             }
+                            onItemClicked()
                         }
-                    }
+                    )
                 }
 
                 is SearchBarUIState.RecentAndFavorites -> {

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/ArriveByUIState.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/ArriveByUIState.kt
@@ -6,7 +6,7 @@ import java.time.Instant
 import java.util.Date
 
 /**
- * Wrapper for state of the search bar in HomeScreen
+ * Wrapper for state of the arrive by selector in Route Options
  */
 sealed class ArriveByUIState {
 

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -199,4 +199,25 @@ class HomeViewModel @Inject constructor(
         locationRepository.instantiate(context)
     }
 
+    /**
+     * Prepares the ViewModel to navigate from the current location to [place].
+     * Adds the place to recents and resets search fields
+     */
+    fun beginRouteOptions(place: Place) {
+        addRecent(place)
+        changeStartLocation(
+            LocationUIState.CurrentLocation
+        )
+        changeEndLocation(
+            LocationUIState.Place(
+                place.name,
+                LatLng(
+                    place.latitude,
+                    place.longitude
+                )
+            )
+        )
+        onQueryChange("")
+    }
+
 }

--- a/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/viewmodels/HomeViewModel.kt
@@ -38,11 +38,6 @@ class HomeViewModel @Inject constructor(
 ) : ViewModel() {
 
     /**
-     * Flow from backend of last route fetched
-     */
-    val lastRouteFlow = routeRepository.lastRouteFlow
-
-    /**
      * The current query in the add favorites search bar, as a StateFlow
      */
     val addSearchQuery: MutableStateFlow<String> = MutableStateFlow("")
@@ -104,13 +99,6 @@ class HomeViewModel @Inject constructor(
         addSearchQuery.debounce(300L).distinctUntilChanged().onEach {
             routeRepository.makeSearch(it)
         }.launchIn(viewModelScope)
-    }
-
-    /**
-     * Perform a search on the string [query]
-     */
-    fun onSearch(query: String) {
-
     }
 
     /**


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
<!-- Summarize your changes here. -->
- Flattened and partially decluttered HomeViewModel with extracted composables
- Removed instances of viewmodels and navcontroller being passed into child composables
- Provide a toast when a location is already favorited, fix closing animation for add favorites bottom sheet
- Fix UI bug where favorites bottom panel can overlap main search area

## Changes Made
<!-- Include details of what your changes actually are and how it is intended to work. -->
- LoadingLocationItems composable to share UI over all instances of location search
- AddFavoritesSearchSheet and BottomSheetContent 
- Separate composable for main search bar
## Test Coverage
<!-- Describe how you tested this feature. Manual testing and/or unit testing. Please include repro steps and/or how to turn the feature on if applicable. -->
Pixel 3a emulator
## Next Steps (delete if not applicable)
<!-- If this is part of a multi-PR change, please describe what changes you plan on addressing in future PRs. -->
To resolve the home screen decluttering issue, we should consider moving toward using abstract base class viewmodels and uistates for entire screens
## Related PRs or Issues (delete if not applicable)
<!-- List related PRs against other branches/repositories. -->
Fixes #79 
## Screenshots (delete if not applicable)
<!-- This could include of screenshots of the new feature / proof that the changes work. -->
[untitled.webm](https://github.com/user-attachments/assets/efc48701-702a-4e1d-bfc8-45ec21948f35)
