### PR TITLE
[ez] Move homeviewmodel dependency injection to homescreen

### DIFF
--- a/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/NavigationController.kt
@@ -22,7 +22,6 @@ import com.cornellappdev.transit.ui.viewmodels.RouteViewModel
  */
 @Composable
 fun NavigationController(
-    homeViewModel: HomeViewModel = hiltViewModel(),
     routeViewModel: RouteViewModel = hiltViewModel()
 ) {
     val navController = rememberNavController()
@@ -32,14 +31,12 @@ fun NavigationController(
         startDestination = "home",
     ) {
         composable("home") {
-            HomeScreen(homeViewModel = homeViewModel, navController = navController)
+            HomeScreen(navController = navController)
         }
 
         composable("details") {
             DetailsScreen(
-                navController = navController,
-                routeViewModel = routeViewModel,
-            )
+                navController = navController, routeViewModel = routeViewModel)
         }
 
         composable("route") {

--- a/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
+++ b/app/src/main/java/com/cornellappdev/transit/ui/screens/HomeScreen.kt
@@ -93,8 +93,8 @@ private enum class HomeSheetValue { Collapsed, PartiallyExpanded, Expanded }
 )
 @Composable
 fun HomeScreen(
-    homeViewModel: HomeViewModel,
     navController: NavController,
+    homeViewModel: HomeViewModel = hiltViewModel(),
     favoritesViewModel: FavoritesViewModel = hiltViewModel()
 ) {
     val scope = rememberCoroutineScope()


### PR DESCRIPTION
<!-- IF A SECTION IS NOT APPLICABLE TO YOU, PLEASE DELETE IT!! -->
<!-- Your title should be able to summarize what changes you’ve made in one sentence. For example: “Exclude staff from the check for follows”. For stacked PRs, please indicate clearly in the title where in the stack you are. For example: “[Eatery Refactor][4/5] Converted all files to MVP model” -->
## Overview
<!-- Summarize your changes here. -->
Move `hiltViewModel()` dependency injection from `NavController` into `HomeScreen`

For some reason, can't do this with `RouteViewModel` as the state between `RouteScreen` and `DetailsScreen` appears to be lost. Might be a good investigation later (low priority)
